### PR TITLE
Fix OpenAI mailbox action tool schema

### DIFF
--- a/apps/api/src/mail-agent.test.ts
+++ b/apps/api/src/mail-agent.test.ts
@@ -3,15 +3,52 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
+  createMailAgent,
   createMailAgentInstructions,
   proposeMailboxActionInputSchema,
+  proposeMailboxActionToolInputSchema,
   queryInvookMailboxInputSchema,
 } from "@invook/ai";
+import type { MailboxActionProposal } from "@invook/contracts";
 import { mailboxActionApprovalDecision } from "@invook/database";
 
 import { hasApprovalPayload } from "./routes/mailbox-actions";
 
 const messageId = "4ca9d9d4-b5a2-4a4e-9cc5-ff2de72ee4b2";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getProviderToolParameters(
+  requestBody: unknown,
+  toolName: string,
+): Record<string, unknown> {
+  assert.ok(isRecord(requestBody));
+  assert.ok(Array.isArray(requestBody.tools));
+  const tools: unknown[] = requestBody.tools;
+  const matchingTool = tools.find(
+    (tool: unknown) =>
+      isRecord(tool) &&
+      isRecord(tool.function) &&
+      tool.function.name === toolName,
+  );
+  assert.ok(isRecord(matchingTool));
+  assert.ok(isRecord(matchingTool.function));
+  assert.ok(isRecord(matchingTool.function.parameters));
+  return matchingTool.function.parameters;
+}
+
+function createProviderStream(chunks: unknown[]): Response {
+  const body = [
+    ...chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`),
+    "data: [DONE]\n\n",
+  ].join("");
+  return new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/event-stream" },
+  });
+}
 
 test("Agent tool schemas reject prompt-injected SQL, object keys, and provider IDs", () => {
   assert.equal(
@@ -25,7 +62,16 @@ test("Agent tool schemas reject prompt-injected SQL, object keys, and provider I
   assert.equal(
     proposeMailboxActionInputSchema.safeParse({
       operation: "trash",
+      messageIds: [messageId],
       providerMessageIds: ["provider-controlled-id"],
+    }).success,
+    false,
+  );
+  assert.equal(
+    proposeMailboxActionInputSchema.safeParse({
+      operation: "save_draft_to_gmail",
+      draftId: messageId,
+      messageIds: [messageId],
     }).success,
     false,
   );
@@ -37,6 +83,159 @@ test("Agent tool schemas reject prompt-injected SQL, object keys, and provider I
     }).success,
     false,
   );
+});
+
+test("OpenAI-compatible streamed requests send an object-rooted mailbox action tool and execute its strict input", async () => {
+  const originalFetch = globalThis.fetch;
+  const originalBaseUrl = process.env.AI_BASE_URL;
+  const originalModel = process.env.AI_MODEL;
+  const providerRequests: unknown[] = [];
+  const proposedActions: Array<{
+    input: unknown;
+    toolCallId: string;
+  }> = [];
+  let requestCount = 0;
+
+  process.env.AI_BASE_URL = "https://provider.invalid/v1";
+  process.env.AI_MODEL = "provider-contract-test";
+  globalThis.fetch = async (_input, init) => {
+    const requestBodyText = init?.body;
+    assert.ok(typeof requestBodyText === "string");
+    const requestBody: unknown = JSON.parse(requestBodyText);
+    providerRequests.push(requestBody);
+    requestCount += 1;
+
+    if (requestCount === 1) {
+      return createProviderStream([
+        {
+          id: "provider-response-1",
+          choices: [
+            {
+              delta: {
+                role: "assistant",
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "mailbox-action-call",
+                    function: {
+                      name: "proposeMailboxAction",
+                      arguments: JSON.stringify({
+                        operation: "archive",
+                        messageIds: [messageId],
+                      }),
+                    },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          id: "provider-response-1",
+          choices: [{ delta: {}, finish_reason: "tool_calls" }],
+        },
+      ]);
+    }
+
+    return createProviderStream([
+      {
+        id: "provider-response-2",
+        choices: [
+          {
+            delta: { role: "assistant", content: "Proposal ready." },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: "provider-response-2",
+        choices: [{ delta: {}, finish_reason: "stop" }],
+      },
+    ]);
+  };
+
+  const proposal: MailboxActionProposal = {
+    id: "9707c256-ee98-45d3-891c-b243429cbd4e",
+    status: "pending",
+    operation: "archive",
+    gmailLabel: null,
+    targets: [],
+    createdAt: "2026-08-13T00:00:00.000Z",
+    approvedAt: null,
+    completedAt: null,
+  };
+
+  try {
+    const agent = createMailAgent({
+      searchMail: async () => [],
+      getThread: async () => null,
+      listAttachments: async () => [],
+      draftReply: async () => {
+        throw new Error("Unexpected draftReply tool call");
+      },
+      queryInvookMailbox: async () => ({
+        status: "available",
+        messages: [],
+        availableGmailLabels: [],
+        availableInvookLabels: [],
+        nextCursor: null,
+      }),
+      proposeMailboxAction: async (input, toolCallId) => {
+        proposedActions.push({ input, toolCallId });
+        return proposal;
+      },
+    });
+    const result = await agent.stream({ prompt: "Archive the selected message" });
+    const textParts: string[] = [];
+    for await (const part of result.textStream) textParts.push(part);
+
+    assert.equal(textParts.join(""), "Proposal ready.");
+    assert.equal(providerRequests.length, 2);
+    for (const toolName of [
+      "searchMail",
+      "getThread",
+      "listAttachments",
+      "draftReply",
+      "queryInvookMailbox",
+      "proposeMailboxAction",
+    ]) {
+      assert.equal(
+        getProviderToolParameters(providerRequests[0], toolName).type,
+        "object",
+      );
+    }
+    const actionParameters = getProviderToolParameters(
+      providerRequests[0],
+      "proposeMailboxAction",
+    );
+    assert.ok(Array.isArray(actionParameters.oneOf));
+    assert.equal(actionParameters.oneOf.length, 3);
+    for (const actionBranch of actionParameters.oneOf) {
+      assert.ok(isRecord(actionBranch));
+      assert.equal(actionBranch.additionalProperties, false);
+    }
+    const validateAction = proposeMailboxActionToolInputSchema.validate;
+    assert.ok(validateAction);
+    const invalidAction = await validateAction({
+      operation: "archive",
+      messageIds: [messageId],
+      providerMessageIds: ["provider-controlled-id"],
+    });
+    assert.equal(invalidAction.success, false);
+    assert.deepEqual(proposedActions, [
+      {
+        input: { operation: "archive", messageIds: [messageId] },
+        toolCallId: "mailbox-action-call",
+      },
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalBaseUrl === undefined) delete process.env.AI_BASE_URL;
+    else process.env.AI_BASE_URL = originalBaseUrl;
+    if (originalModel === undefined) delete process.env.AI_MODEL;
+    else process.env.AI_MODEL = originalModel;
+  }
 });
 
 test("Agent instructions preserve untrusted-content and grounded-citation boundaries", () => {

--- a/packages/ai/src/mail-agent.ts
+++ b/packages/ai/src/mail-agent.ts
@@ -3,7 +3,7 @@ import type {
   MailboxQueryResult,
   MailSearchResult,
 } from "@invook/contracts";
-import { isStepCount, tool, ToolLoopAgent } from "ai";
+import { isStepCount, jsonSchema, tool, ToolLoopAgent, zodSchema } from "ai";
 import { z } from "zod";
 
 import { getAiModel } from "./model";
@@ -106,6 +106,19 @@ export type ProposeMailboxActionInput = z.infer<
   typeof proposeMailboxActionInputSchema
 >;
 
+const proposeMailboxActionZodInputSchema = zodSchema(
+  proposeMailboxActionInputSchema,
+);
+
+export const proposeMailboxActionToolInputSchema =
+  jsonSchema<ProposeMailboxActionInput>(
+    async () => ({
+      ...(await proposeMailboxActionZodInputSchema.jsonSchema),
+      type: "object",
+    }),
+    { validate: proposeMailboxActionZodInputSchema.validate },
+  );
+
 export function createMailAgentInstructions(context?: {
   currentThreadId: string;
 }): string {
@@ -174,7 +187,7 @@ export function createMailAgent(
       proposeMailboxAction: tool({
         description:
           "Persist a non-executing Gmail mutation proposal for exact local message IDs or one existing AI draft ID. This never writes to Gmail; the user must approve the returned proposal card.",
-        inputSchema: proposeMailboxActionInputSchema,
+        inputSchema: proposeMailboxActionToolInputSchema,
         execute: (input, { toolCallId }) =>
           operations.proposeMailboxAction(input, toolCallId),
       }),


### PR DESCRIPTION
## Summary
- keep the strict mailbox action discriminated union as the runtime validator
- expose an OpenAI-compatible object-rooted JSON Schema without weakening archive, read-state, trash, Gmail-label, or save-draft inputs
- add a streamed OpenAI-compatible contract test that inspects the serialized provider request and executes a mailbox action tool across two model turns

## Provider evidence
Before: proposeMailboxAction parameters serialized with oneOf branches but no top-level type, which OpenAI rejected with HTTP 400 invalid_function_parameters.

After: the actual serialized request contains parameters.type = object, retains all three strict oneOf branches with additionalProperties = false, rejects provider IDs through runtime validation, executes the proposal tool, and streams the second model response.

## Verification
- pnpm --filter @invook/ai typecheck
- pnpm --filter @invook/api typecheck
- pnpm --filter @invook/api test
- make verify
- built and ran the PR 2 API image against the post-reset local stack; API healthy and required OAuth/AI variables present

## Pending authenticated live check
PR 1 completed the clean reset and signup-screen baseline. A real Google sign-in was attempted with the only available browser account, but Google returned 403 access_denied because the OAuth app is in testing mode and that account is not a developer-approved tester. No authenticated /v1/agent request can be made until that account is added to the OAuth test users or an approved account signs in. No provider body, credential, or account identity is included here.