### PR TITLE
Compose new messages as Gmail drafts

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "node ../../scripts/run-with-root-env.mjs node_modules/tsx/dist/cli.mjs watch src/index.ts",
     "start": "node ../../scripts/run-with-root-env.mjs node_modules/tsx/dist/cli.mjs src/index.ts",
-    "test": "node --import tsx --test src/app.test.ts src/mail-agent.test.ts src/services/drafts.test.ts",
+    "test": "node --import tsx --test src/app.test.ts src/mail-agent.test.ts src/services/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -378,6 +378,8 @@ test("Gmail provider writes require an authenticated session", async () => {
     { method: "PATCH", url: "/v1/gmail/messages/not-a-uuid/labels" },
     { method: "PUT", url: "/v1/gmail/drafts/not-a-uuid" },
     { method: "DELETE", url: "/v1/gmail/drafts/not-a-uuid" },
+    { method: "POST", url: "/v1/gmail/compose-drafts" },
+    { method: "PUT", url: "/v1/gmail/compose-drafts/provider-draft" },
     { method: "POST", url: "/v1/drafts/not-a-uuid/save-to-gmail" },
   ] as const;
 

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,6 +9,7 @@ import {
   type AttachmentRouteDependencies,
 } from "./routes/attachments";
 import { registerBatchWebhookRoutes } from "./routes/batch-webhook";
+import { registerComposeDraftRoutes } from "./routes/compose-drafts";
 import { registerDraftRoutes } from "./routes/drafts";
 import { registerGmailProviderRoutes } from "./routes/gmail-provider";
 import { registerHealthRoutes } from "./routes/health";
@@ -87,6 +88,7 @@ export async function buildApi(options: {
   await api.register(registerLabelRoutes, { prefix: "/v1/labels" });
   await api.register(registerThreadLabelRoutes, { prefix: "/v1/threads" });
   await api.register(registerDraftRoutes);
+  await api.register(registerComposeDraftRoutes);
   await api.register(registerGmailProviderRoutes);
 
   api.setNotFoundHandler(async (request, reply) => {

--- a/apps/api/src/routes/compose-drafts.ts
+++ b/apps/api/src/routes/compose-drafts.ts
@@ -1,0 +1,156 @@
+import type { FastifyPluginAsync } from "fastify";
+import { validate as validateUuid } from "uuid";
+
+import {
+  validateGmailComposeDraftFields,
+  type CreateGmailComposeDraftRequest,
+} from "@invook/contracts";
+import { GmailDraftWriteConflictError } from "@invook/database";
+import { GmailApiError } from "@invook/gmail";
+
+import { mutationAccessHooks } from "../access";
+import { sendJson, sendProblem } from "../responses";
+import {
+  GmailDraftWritePendingError,
+  saveComposeDraft,
+} from "../services/compose-drafts";
+import {
+  getGmailProviderAccessForRequest,
+  sendGmailWriteProblem,
+} from "./gmail-provider-access";
+
+type ProviderDraftParams = { providerDraftId: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function parseGmailComposeDraftRequest(
+  body: unknown,
+): CreateGmailComposeDraftRequest | null {
+  if (!isRecord(body)) return null;
+  const allowedKeys = new Set([
+    "idempotencyKey",
+    "recipients",
+    "subject",
+    "body",
+  ]);
+  if (Object.keys(body).some((key) => !allowedKeys.has(key))) return null;
+  if (
+    typeof body.idempotencyKey !== "string" ||
+    !validateUuid(body.idempotencyKey) ||
+    !Array.isArray(body.recipients) ||
+    body.recipients.some((recipient) => typeof recipient !== "string") ||
+    typeof body.subject !== "string" ||
+    typeof body.body !== "string"
+  ) {
+    return null;
+  }
+  const validation = validateGmailComposeDraftFields({
+    recipients: body.recipients as string[],
+    subject: body.subject,
+    body: body.body,
+  });
+  if (!validation.valid) return null;
+  return {
+    idempotencyKey: body.idempotencyKey,
+    ...validation.fields,
+  };
+}
+
+function isProviderDraftId(value: string): boolean {
+  return /^[A-Za-z0-9_-]{1,256}$/.test(value);
+}
+
+async function sendComposeDraftError(
+  error: unknown,
+  request: Parameters<typeof sendProblem>[0],
+  reply: Parameters<typeof sendProblem>[1],
+): Promise<boolean> {
+  if (error instanceof GmailDraftWriteConflictError) {
+    await sendProblem(request, reply, 409, "Idempotency key conflicts with another draft save");
+    return true;
+  }
+  if (error instanceof GmailDraftWritePendingError) {
+    await sendProblem(request, reply, 409, "Previous Gmail draft save is still being resolved");
+    return true;
+  }
+  if (error instanceof GmailApiError) {
+    await sendGmailWriteProblem(error, request, reply);
+    return true;
+  }
+  return false;
+}
+
+export const registerComposeDraftRoutes: FastifyPluginAsync = async (api) => {
+  api.post<{ Body: unknown }>(
+    "/v1/gmail/compose-drafts",
+    { onRequest: mutationAccessHooks },
+    async (request, reply) => {
+      const session = request.invookSession;
+      if (!session) return;
+      const draft = parseGmailComposeDraftRequest(request.body);
+      if (!draft) {
+        await sendProblem(request, reply, 400, "Gmail compose draft input is invalid");
+        return;
+      }
+      const access = await getGmailProviderAccessForRequest(request, reply);
+      if (!access) return;
+      try {
+        const result = await saveComposeDraft({
+          userId: session.userId,
+          access,
+          operation: "create",
+          idempotencyKey: draft.idempotencyKey,
+          fields: {
+            recipients: draft.recipients,
+            subject: draft.subject,
+            body: draft.body,
+          },
+        });
+        await sendJson(reply, 201, result);
+      } catch (error) {
+        if (await sendComposeDraftError(error, request, reply)) return;
+        throw error;
+      }
+    },
+  );
+
+  api.put<{ Params: ProviderDraftParams; Body: unknown }>(
+    "/v1/gmail/compose-drafts/:providerDraftId",
+    { onRequest: mutationAccessHooks },
+    async (request, reply) => {
+      const session = request.invookSession;
+      if (!session) return;
+      if (!isProviderDraftId(request.params.providerDraftId)) {
+        await sendProblem(request, reply, 400, "Gmail provider draft ID is invalid");
+        return;
+      }
+      const draft = parseGmailComposeDraftRequest(request.body);
+      if (!draft) {
+        await sendProblem(request, reply, 400, "Gmail compose draft input is invalid");
+        return;
+      }
+      const access = await getGmailProviderAccessForRequest(request, reply);
+      if (!access) return;
+      try {
+        const result = await saveComposeDraft({
+          userId: session.userId,
+          access,
+          operation: "update",
+          idempotencyKey: draft.idempotencyKey,
+          fields: {
+            recipients: draft.recipients,
+            subject: draft.subject,
+            body: draft.body,
+          },
+          providerDraftId: request.params.providerDraftId,
+        });
+        await sendJson(reply, 200, result);
+      } catch (error) {
+        if (await sendComposeDraftError(error, request, reply)) return;
+        throw error;
+      }
+    },
+  );
+};

--- a/apps/api/src/routes/compose-drafts.ts
+++ b/apps/api/src/routes/compose-drafts.ts
@@ -47,7 +47,9 @@ export function parseGmailComposeDraftRequest(
     return null;
   }
   const validation = validateGmailComposeDraftFields({
-    recipients: body.recipients as string[],
+    recipients: body.recipients.filter(
+      (recipient): recipient is string => typeof recipient === "string",
+    ),
     subject: body.subject,
     body: body.body,
   });

--- a/apps/api/src/routes/gmail-provider-access.ts
+++ b/apps/api/src/routes/gmail-provider-access.ts
@@ -1,0 +1,69 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+import { GmailApiError } from "@invook/gmail";
+
+import { sendProblem } from "../responses";
+import {
+  getGmailProviderAccess,
+  GmailProviderConfigurationError,
+  GmailProviderReconnectRequiredError,
+  type GmailProviderAccess,
+} from "../services/gmail-provider";
+
+export async function getGmailProviderAccessForRequest(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<GmailProviderAccess | null> {
+  const session = request.invookSession;
+  if (!session) return null;
+  try {
+    const result = await getGmailProviderAccess(session.userId);
+    if (result.status === "not_found") {
+      await sendProblem(request, reply, 404, "Connected Gmail account not found");
+      return null;
+    }
+    if (result.status === "replica_not_ready") {
+      await sendProblem(request, reply, 409, "Gmail mailbox replica is not ready");
+      return null;
+    }
+    return result.access;
+  } catch (error) {
+    if (error instanceof GmailProviderConfigurationError) {
+      await sendProblem(request, reply, 503, "Gmail provider writes are not configured");
+      return null;
+    }
+    if (error instanceof GmailProviderReconnectRequiredError) {
+      await sendProblem(request, reply, 409, "Gmail account must be reconnected");
+      return null;
+    }
+    if (error instanceof GmailApiError) {
+      await sendGmailWriteProblem(error, request, reply);
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function sendGmailWriteProblem(
+  error: GmailApiError,
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> {
+  if (error.status === 400) {
+    await sendProblem(request, reply, 400, "Gmail rejected the provider write");
+    return;
+  }
+  if (error.status === 404) {
+    await sendProblem(request, reply, 404, "Gmail resource not found");
+    return;
+  }
+  if (error.status === 409) {
+    await sendProblem(request, reply, 409, "Gmail provider write conflicted");
+    return;
+  }
+  if (error.status === 0 || error.status === 429 || error.status >= 500) {
+    await sendProblem(request, reply, 503, "Gmail provider is unavailable");
+    return;
+  }
+  await sendProblem(request, reply, 502, "Gmail provider write failed");
+}

--- a/apps/api/src/routes/gmail-provider.ts
+++ b/apps/api/src/routes/gmail-provider.ts
@@ -1,8 +1,4 @@
-import type {
-  FastifyPluginAsync,
-  FastifyReply,
-  FastifyRequest,
-} from "fastify";
+import type { FastifyPluginAsync } from "fastify";
 
 import {
   enqueueGmailHistoryCatchup,
@@ -30,12 +26,11 @@ import {
   requireUuidParameter,
 } from "../access";
 import { sendJson, sendProblem } from "../responses";
+import type { GmailProviderAccess } from "../services/gmail-provider";
 import {
-  getGmailProviderAccess,
-  GmailProviderConfigurationError,
-  GmailProviderReconnectRequiredError,
-  type GmailProviderAccess,
-} from "../services/gmail-provider";
+  getGmailProviderAccessForRequest,
+  sendGmailWriteProblem,
+} from "./gmail-provider-access";
 
 type GmailLabelParams = { gmailLabelId: string };
 type GmailMessageParams = { messageId: string };
@@ -118,64 +113,6 @@ function parseUuidArray(value: unknown): string[] | null {
   return [...new Set(values)];
 }
 
-async function providerAccess(
-  request: FastifyRequest,
-  reply: FastifyReply,
-): Promise<GmailProviderAccess | null> {
-  const session = request.invookSession;
-  if (!session) return null;
-  try {
-    const result = await getGmailProviderAccess(session.userId);
-    if (result.status === "not_found") {
-      await sendProblem(request, reply, 404, "Connected Gmail account not found");
-      return null;
-    }
-    if (result.status === "replica_not_ready") {
-      await sendProblem(request, reply, 409, "Gmail mailbox replica is not ready");
-      return null;
-    }
-    return result.access;
-  } catch (error) {
-    if (error instanceof GmailProviderConfigurationError) {
-      await sendProblem(request, reply, 503, "Gmail provider writes are not configured");
-      return null;
-    }
-    if (error instanceof GmailProviderReconnectRequiredError) {
-      await sendProblem(request, reply, 409, "Gmail account must be reconnected");
-      return null;
-    }
-    if (error instanceof GmailApiError) {
-      await sendGmailWriteProblem(error, request, reply);
-      return null;
-    }
-    throw error;
-  }
-}
-
-async function sendGmailWriteProblem(
-  error: GmailApiError,
-  request: FastifyRequest,
-  reply: FastifyReply,
-) {
-  if (error.status === 400) {
-    await sendProblem(request, reply, 400, "Gmail rejected the provider write");
-    return;
-  }
-  if (error.status === 404) {
-    await sendProblem(request, reply, 404, "Gmail resource not found");
-    return;
-  }
-  if (error.status === 409) {
-    await sendProblem(request, reply, 409, "Gmail provider write conflicted");
-    return;
-  }
-  if (error.status === 0 || error.status === 429 || error.status >= 500) {
-    await sendProblem(request, reply, 503, "Gmail provider is unavailable");
-    return;
-  }
-  await sendProblem(request, reply, 502, "Gmail provider write failed");
-}
-
 async function enqueueProviderCatchup(
   userId: string,
   access: GmailProviderAccess,
@@ -199,7 +136,7 @@ export const registerGmailProviderRoutes: FastifyPluginAsync = async (api) => {
         await sendProblem(request, reply, 400, "Gmail label input is invalid");
         return;
       }
-      const access = await providerAccess(request, reply);
+      const access = await getGmailProviderAccessForRequest(request, reply);
       if (!access) return;
       try {
         const created = await createGmailLabel(access.accessToken, label as GmailLabelInput);
@@ -232,7 +169,7 @@ export const registerGmailProviderRoutes: FastifyPluginAsync = async (api) => {
         return;
       }
       const [access, label] = await Promise.all([
-        providerAccess(request, reply),
+        getGmailProviderAccessForRequest(request, reply),
         getGmailProviderLabelForUser({
           userId: session.userId,
           gmailLabelId: request.params.gmailLabelId,
@@ -277,7 +214,7 @@ export const registerGmailProviderRoutes: FastifyPluginAsync = async (api) => {
       const session = request.invookSession;
       if (!session) return;
       const [access, label] = await Promise.all([
-        providerAccess(request, reply),
+        getGmailProviderAccessForRequest(request, reply),
         getGmailProviderLabelForUser({
           userId: session.userId,
           gmailLabelId: request.params.gmailLabelId,
@@ -334,7 +271,7 @@ export const registerGmailProviderRoutes: FastifyPluginAsync = async (api) => {
       }
       const gmailLabelIds = [...new Set([...addLabelIds, ...removeLabelIds])];
       const [access, context] = await Promise.all([
-        providerAccess(request, reply),
+        getGmailProviderAccessForRequest(request, reply),
         getGmailMessageLabelMutationContext({
           userId: session.userId,
           messageId: request.params.messageId,
@@ -392,7 +329,7 @@ export const registerGmailProviderRoutes: FastifyPluginAsync = async (api) => {
         return;
       }
       const [access, draft] = await Promise.all([
-        providerAccess(request, reply),
+        getGmailProviderAccessForRequest(request, reply),
         getGmailDraftResourceForUser({
           userId: session.userId,
           gmailDraftId: request.params.gmailDraftId,
@@ -436,7 +373,7 @@ export const registerGmailProviderRoutes: FastifyPluginAsync = async (api) => {
       const session = request.invookSession;
       if (!session) return;
       const [access, draft] = await Promise.all([
-        providerAccess(request, reply),
+        getGmailProviderAccessForRequest(request, reply),
         getGmailDraftResourceForUser({
           userId: session.userId,
           gmailDraftId: request.params.gmailDraftId,
@@ -473,7 +410,7 @@ export const registerGmailProviderRoutes: FastifyPluginAsync = async (api) => {
       const session = request.invookSession;
       if (!session) return;
       const [access, draft] = await Promise.all([
-        providerAccess(request, reply),
+        getGmailProviderAccessForRequest(request, reply),
         getAiReplyDraftForGmailSave({
           userId: session.userId,
           draftId: request.params.draftId,

--- a/apps/api/src/services/compose-drafts.test.ts
+++ b/apps/api/src/services/compose-drafts.test.ts
@@ -1,0 +1,222 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BeginGmailDraftWriteResult } from "@invook/database";
+
+import { parseGmailComposeDraftRequest } from "../routes/compose-drafts";
+import {
+  saveComposeDraft,
+  type ComposeDraftDependencies,
+} from "./compose-drafts";
+
+const userId = "11111111-1111-4111-8111-111111111111";
+const accountId = "22222222-2222-4222-8222-222222222222";
+const idempotencyKey = "33333333-3333-4333-8333-333333333333";
+const access = {
+  accountId,
+  accessToken: "access-token",
+  email: "owner@example.com",
+};
+const fields = {
+  recipients: ["recipient@example.com"],
+  subject: "Subject",
+  body: "Draft body",
+};
+
+function gmailDraft(
+  providerDraftId = "provider-draft",
+  providerMessageId = "provider-message",
+  providerThreadId = "provider-thread",
+) {
+  return {
+    id: providerDraftId,
+    message: {
+      id: providerMessageId,
+      threadId: providerThreadId,
+      raw: "",
+    },
+  };
+}
+
+function memoryDependencies(input: {
+  failFirstCatchup?: boolean;
+} = {}): {
+  dependencies: ComposeDraftDependencies;
+  counts: { create: number; update: number; catchup: number };
+} {
+  let stored: BeginGmailDraftWriteResult | null = null;
+  const counts = { create: 0, update: 0, catchup: 0 };
+  const dependencies: ComposeDraftDependencies = {
+    beginWrite: async () => {
+      if (stored) return stored;
+      stored = { outcome: "claimed", operationId: "operation-1" };
+      return stored;
+    },
+    completeWrite: async ({ operationId, result }) => {
+      stored = { outcome: "complete", operationId, result };
+    },
+    abandonWrite: async () => {
+      stored = null;
+    },
+    createDraft: async () => {
+      counts.create += 1;
+      return gmailDraft();
+    },
+    getDraft: async () => gmailDraft(),
+    listDrafts: async () => ({ drafts: [] }),
+    updateDraft: async () => {
+      counts.update += 1;
+      return gmailDraft();
+    },
+    enqueueCatchup: async ({ sourceId }) => {
+      counts.catchup += 1;
+      assert.equal(sourceId, "compose-draft:operation-1");
+      if (input.failFirstCatchup && counts.catchup === 1) {
+        throw new Error("outbox unavailable");
+      }
+      return "catchup-step";
+    },
+  };
+  return { dependencies, counts };
+}
+
+test("compose draft admission accepts only the exact validated wire contract", () => {
+  assert.deepEqual(
+    parseGmailComposeDraftRequest({ idempotencyKey, ...fields }),
+    { idempotencyKey, ...fields },
+  );
+  assert.equal(
+    parseGmailComposeDraftRequest({
+      idempotencyKey,
+      ...fields,
+      unexpected: "field",
+    }),
+    null,
+  );
+  assert.equal(
+    parseGmailComposeDraftRequest({
+      idempotencyKey: "not-a-uuid",
+      ...fields,
+    }),
+    null,
+  );
+  assert.equal(
+    parseGmailComposeDraftRequest({
+      idempotencyKey,
+      ...fields,
+      subject: "Subject\r\nBcc: hidden@example.com",
+    }),
+    null,
+  );
+});
+
+test("a completed create retry reuses the provider result without creating a duplicate", async () => {
+  const { dependencies, counts } = memoryDependencies();
+  const input = {
+    userId,
+    access,
+    operation: "create" as const,
+    idempotencyKey,
+    fields,
+  };
+
+  const first = await saveComposeDraft(input, dependencies);
+  const retry = await saveComposeDraft(input, dependencies);
+
+  assert.deepEqual(retry, first);
+  assert.equal(counts.create, 1);
+  assert.equal(counts.catchup, 2);
+});
+
+test("a retry after catch-up failure does not repeat the completed provider write", async () => {
+  const { dependencies, counts } = memoryDependencies({ failFirstCatchup: true });
+  const input = {
+    userId,
+    access,
+    operation: "create" as const,
+    idempotencyKey,
+    fields,
+  };
+
+  await assert.rejects(saveComposeDraft(input, dependencies), /outbox unavailable/);
+  const retry = await saveComposeDraft(input, dependencies);
+
+  assert.equal(retry.stepId, "catchup-step");
+  assert.equal(counts.create, 1);
+  assert.equal(counts.catchup, 2);
+});
+
+test("an ambiguous pending write recovers by its stable RFC 822 message ID", async () => {
+  let completed = false;
+  const dependencies: ComposeDraftDependencies = {
+    beginWrite: async () => ({ outcome: "pending", operationId: "operation-1" }),
+    completeWrite: async () => {
+      completed = true;
+    },
+    abandonWrite: async () => undefined,
+    createDraft: async () => {
+      throw new Error("create must not repeat");
+    },
+    getDraft: async () => gmailDraft(),
+    listDrafts: async (_accessToken, options) => {
+      assert.equal(
+        options.query,
+        "rfc822msgid:invook-compose-operation-1@invook.invalid",
+      );
+      return {
+        drafts: [
+          {
+            id: "provider-draft",
+            message: { id: "provider-message", threadId: "provider-thread" },
+          },
+        ],
+      };
+    },
+    updateDraft: async () => {
+      throw new Error("update must not repeat");
+    },
+    enqueueCatchup: async () => "catchup-step",
+  };
+
+  const result = await saveComposeDraft(
+    {
+      userId,
+      access,
+      operation: "create",
+      idempotencyKey,
+      fields,
+    },
+    dependencies,
+  );
+
+  assert.equal(completed, true);
+  assert.equal(result.draft.providerDraftId, "provider-draft");
+});
+
+test("updating reads the provider thread and replaces the existing Gmail draft", async () => {
+  const { dependencies, counts } = memoryDependencies();
+  let updateThreadId: string | undefined;
+  dependencies.updateDraft = async (_accessToken, providerDraftId, write) => {
+    counts.update += 1;
+    assert.equal(providerDraftId, "provider-draft");
+    updateThreadId = write.threadId;
+    assert.match(write.raw.toString("utf8"), /\r\n\r\nDraft body$/);
+    return gmailDraft();
+  };
+
+  await saveComposeDraft(
+    {
+      userId,
+      access,
+      operation: "update",
+      idempotencyKey,
+      fields,
+      providerDraftId: "provider-draft",
+    },
+    dependencies,
+  );
+
+  assert.equal(counts.create, 0);
+  assert.equal(counts.update, 1);
+  assert.equal(updateThreadId, "provider-thread");
+});

--- a/apps/api/src/services/compose-drafts.ts
+++ b/apps/api/src/services/compose-drafts.ts
@@ -1,0 +1,217 @@
+import { createHash } from "node:crypto";
+
+import type {
+  GmailComposeDraftFields,
+  GmailComposeDraftResponse,
+} from "@invook/contracts";
+import {
+  abandonPendingGmailDraftWrite,
+  beginGmailDraftWrite,
+  completeGmailDraftWrite,
+  enqueueGmailHistoryCatchup,
+  type BeginGmailDraftWriteResult,
+  type GmailDraftWriteOperation,
+  type GmailDraftWriteResult,
+} from "@invook/database";
+import {
+  composePlainTextGmailMessage,
+  createGmailDraft,
+  getGmailDraft,
+  GmailApiError,
+  listGmailDrafts,
+  updateGmailDraft,
+  type GmailDraft,
+  type GmailDraftPage,
+} from "@invook/gmail";
+
+import type { GmailProviderAccess } from "./gmail-provider";
+
+export class GmailDraftWritePendingError extends Error {
+  constructor() {
+    super("The previous Gmail draft write is still being resolved.");
+    this.name = "GmailDraftWritePendingError";
+  }
+}
+
+export interface SaveComposeDraftInput {
+  userId: string;
+  access: GmailProviderAccess;
+  operation: GmailDraftWriteOperation;
+  idempotencyKey: string;
+  fields: GmailComposeDraftFields;
+  providerDraftId?: string;
+}
+
+export interface ComposeDraftDependencies {
+  beginWrite: typeof beginGmailDraftWrite;
+  completeWrite: typeof completeGmailDraftWrite;
+  abandonWrite: typeof abandonPendingGmailDraftWrite;
+  createDraft: typeof createGmailDraft;
+  getDraft: typeof getGmailDraft;
+  listDrafts: typeof listGmailDrafts;
+  updateDraft: typeof updateGmailDraft;
+  enqueueCatchup: typeof enqueueGmailHistoryCatchup;
+}
+
+const defaultDependencies: ComposeDraftDependencies = {
+  beginWrite: beginGmailDraftWrite,
+  completeWrite: completeGmailDraftWrite,
+  abandonWrite: abandonPendingGmailDraftWrite,
+  createDraft: createGmailDraft,
+  getDraft: getGmailDraft,
+  listDrafts: listGmailDrafts,
+  updateDraft: updateGmailDraft,
+  enqueueCatchup: enqueueGmailHistoryCatchup,
+};
+
+function requestFingerprint(input: SaveComposeDraftInput): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        operation: input.operation,
+        providerDraftId: input.providerDraftId ?? null,
+        recipients: input.fields.recipients,
+        subject: input.fields.subject,
+        body: input.fields.body,
+      }),
+      "utf8",
+    )
+    .digest("hex");
+}
+
+function operationMessageId(operationId: string): string {
+  return `invook-compose-${operationId}@invook.invalid`;
+}
+
+function providerResult(draft: GmailDraft): GmailDraftWriteResult {
+  return {
+    providerDraftId: draft.id,
+    providerMessageId: draft.message.id,
+    providerThreadId: draft.message.threadId,
+  };
+}
+
+function draftPageResult(page: GmailDraftPage): GmailDraftWriteResult | null {
+  const drafts = page.drafts ?? [];
+  if (drafts.length !== 1) return null;
+  const draft = drafts[0];
+  if (!draft) return null;
+  return {
+    providerDraftId: draft.id,
+    providerMessageId: draft.message.id,
+    providerThreadId: draft.message.threadId,
+  };
+}
+
+async function enqueueCatchup(
+  input: SaveComposeDraftInput,
+  operationId: string,
+  dependencies: ComposeDraftDependencies,
+): Promise<string> {
+  return dependencies.enqueueCatchup({
+    userId: input.userId,
+    accountId: input.access.accountId,
+    reason: "provider_write",
+    sourceId: `compose-draft:${operationId}`,
+  });
+}
+
+async function completedResponse(
+  input: SaveComposeDraftInput,
+  operationId: string,
+  result: GmailDraftWriteResult,
+  dependencies: ComposeDraftDependencies,
+): Promise<GmailComposeDraftResponse> {
+  const stepId = await enqueueCatchup(input, operationId, dependencies);
+  return { draft: result, stepId };
+}
+
+async function recoverPendingWrite(
+  input: SaveComposeDraftInput,
+  pending: Extract<BeginGmailDraftWriteResult, { outcome: "pending" }>,
+  dependencies: ComposeDraftDependencies,
+): Promise<GmailComposeDraftResponse> {
+  const page = await dependencies.listDrafts(input.access.accessToken, {
+    maxResults: 2,
+    query: `rfc822msgid:${operationMessageId(pending.operationId)}`,
+  });
+  const result = draftPageResult(page);
+  if (!result) throw new GmailDraftWritePendingError();
+  await dependencies.completeWrite({
+    operationId: pending.operationId,
+    userId: input.userId,
+    result,
+  });
+  return completedResponse(input, pending.operationId, result, dependencies);
+}
+
+export async function saveComposeDraft(
+  input: SaveComposeDraftInput,
+  dependencies: ComposeDraftDependencies = defaultDependencies,
+): Promise<GmailComposeDraftResponse> {
+  const write = await dependencies.beginWrite({
+    userId: input.userId,
+    accountId: input.access.accountId,
+    operation: input.operation,
+    idempotencyKey: input.idempotencyKey,
+    requestFingerprint: requestFingerprint(input),
+  });
+  if (write.outcome === "complete") {
+    return completedResponse(input, write.operationId, write.result, dependencies);
+  }
+  if (write.outcome === "pending") {
+    return recoverPendingWrite(input, write, dependencies);
+  }
+
+  const raw = composePlainTextGmailMessage({
+    accountEmail: input.access.email,
+    ...input.fields,
+    messageId: operationMessageId(write.operationId),
+  });
+  if (!raw) {
+    await dependencies.abandonWrite({
+      operationId: write.operationId,
+      userId: input.userId,
+    });
+    throw new Error("The Gmail message could not be composed.");
+  }
+
+  let hasStartedProviderWrite = false;
+  try {
+    let saved: GmailDraft;
+    if (input.operation === "create") {
+      hasStartedProviderWrite = true;
+      saved = await dependencies.createDraft(input.access.accessToken, { raw });
+    } else {
+      if (!input.providerDraftId) {
+        throw new Error("A provider draft ID is required to update a Gmail draft.");
+      }
+      const current = await dependencies.getDraft(
+        input.access.accessToken,
+        input.providerDraftId,
+      );
+      hasStartedProviderWrite = true;
+      saved = await dependencies.updateDraft(
+        input.access.accessToken,
+        input.providerDraftId,
+        { raw, threadId: current.message.threadId },
+      );
+    }
+    const result = providerResult(saved);
+    await dependencies.completeWrite({
+      operationId: write.operationId,
+      userId: input.userId,
+      result,
+    });
+    return completedResponse(input, write.operationId, result, dependencies);
+  } catch (error) {
+    const isKnownProviderRejection = error instanceof GmailApiError && error.status > 0;
+    if (!hasStartedProviderWrite || isKnownProviderRejection) {
+      await dependencies.abandonWrite({
+        operationId: write.operationId,
+        userId: input.userId,
+      });
+    }
+    throw error;
+  }
+}

--- a/apps/web/src/app/mail/page.tsx
+++ b/apps/web/src/app/mail/page.tsx
@@ -7,6 +7,7 @@ import { validate as validateUuid } from "uuid";
 import { mailboxViews } from "@invook/contracts";
 
 import { AgentPanel } from "@/components/mail/agent-panel";
+import { ComposeSurface } from "@/components/mail/compose-surface";
 import { MailList } from "@/components/mail/mail-list";
 import { MailboxEventSubscriber } from "@/components/mail/mailbox-event-subscriber";
 import { MailSidebar } from "@/components/mail/mail-sidebar";
@@ -20,7 +21,6 @@ import type {
   StaticMailboxView,
 } from "@/components/mail/types";
 import {
-  ComposeSurface,
   PendingSurface,
   SearchResultsSurface,
   SearchSurface,

--- a/apps/web/src/components/mail/compose-draft-state.test.ts
+++ b/apps/web/src/components/mail/compose-draft-state.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  composeDraftReducer,
+  createComposeDraftState,
+} from "./compose-draft-state";
+
+test("a failed save preserves the idempotency key for an exact retry", () => {
+  const initial = createComposeDraftState("save-key-1");
+  const saving = composeDraftReducer(initial, { type: "saving" });
+  const failed = composeDraftReducer(saving, {
+    type: "error",
+    message: "Gmail is unavailable.",
+  });
+
+  assert.equal(failed.idempotencyKey, "save-key-1");
+  assert.equal(failed.status, "error");
+});
+
+test("editing after a save rotates the key and retains the provider draft identity", () => {
+  const saved = composeDraftReducer(createComposeDraftState("save-key-1"), {
+    type: "saved",
+    draft: {
+      providerDraftId: "provider-draft",
+      providerMessageId: "provider-message",
+      providerThreadId: "provider-thread",
+    },
+  });
+  const edited = composeDraftReducer(saved, {
+    type: "edit",
+    field: "body",
+    value: "Revised body",
+    idempotencyKey: "save-key-2",
+  });
+
+  assert.equal(edited.idempotencyKey, "save-key-2");
+  assert.equal(edited.status, "editing");
+  assert.equal(edited.providerDraft?.providerDraftId, "provider-draft");
+});
+
+test("a successful save exposes an explicit convergence state", () => {
+  const saved = composeDraftReducer(createComposeDraftState("save-key-1"), {
+    type: "saved",
+    draft: {
+      providerDraftId: "provider-draft",
+      providerMessageId: "provider-message",
+      providerThreadId: "provider-thread",
+    },
+  });
+
+  assert.equal(saved.status, "saved");
+  assert.match(saved.message ?? "", /Gmail history catches up/);
+});

--- a/apps/web/src/components/mail/compose-draft-state.ts
+++ b/apps/web/src/components/mail/compose-draft-state.ts
@@ -1,0 +1,68 @@
+import type { GmailComposeDraft } from "@invook/contracts";
+
+export type ComposeDraftStatus = "editing" | "saving" | "saved" | "error";
+
+export interface ComposeDraftState {
+  recipients: string;
+  subject: string;
+  body: string;
+  idempotencyKey: string;
+  providerDraft: GmailComposeDraft | null;
+  status: ComposeDraftStatus;
+  message: string | null;
+}
+
+export type ComposeDraftAction =
+  | {
+      type: "edit";
+      field: "recipients" | "subject" | "body";
+      value: string;
+      idempotencyKey: string;
+    }
+  | { type: "saving" }
+  | { type: "saved"; draft: GmailComposeDraft }
+  | { type: "error"; message: string };
+
+export function createComposeDraftState(idempotencyKey: string): ComposeDraftState {
+  return {
+    recipients: "",
+    subject: "",
+    body: "",
+    idempotencyKey,
+    providerDraft: null,
+    status: "editing",
+    message: null,
+  };
+}
+
+export function composeDraftReducer(
+  state: ComposeDraftState,
+  action: ComposeDraftAction,
+): ComposeDraftState {
+  switch (action.type) {
+    case "edit":
+      return {
+        ...state,
+        [action.field]: action.value,
+        idempotencyKey: action.idempotencyKey,
+        status: "editing",
+        message: null,
+      };
+    case "saving":
+      return { ...state, status: "saving", message: null };
+    case "saved":
+      return {
+        ...state,
+        providerDraft: action.draft,
+        status: "saved",
+        message:
+          "Saved to Gmail drafts. Invook will reflect it here after Gmail history catches up.",
+      };
+    case "error":
+      return { ...state, status: "error", message: action.message };
+    default: {
+      const exhaustiveAction: never = action;
+      return exhaustiveAction;
+    }
+  }
+}

--- a/apps/web/src/components/mail/compose-surface.tsx
+++ b/apps/web/src/components/mail/compose-surface.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import {
+  CheckmarkCircle02Icon,
+  MailAdd01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import {
+  GMAIL_COMPOSE_MAX_BODY_LENGTH,
+  GMAIL_COMPOSE_MAX_SUBJECT_LENGTH,
+  parseGmailComposeRecipients,
+  validateGmailComposeDraftFields,
+} from "@invook/contracts";
+import { type FormEvent, useReducer } from "react";
+import { v4 as uuidv4 } from "uuid";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  composeDraftReducer,
+  createComposeDraftState,
+} from "@/components/mail/compose-draft-state";
+import { SurfaceHeader } from "@/components/mail/surface-header";
+import {
+  createGmailComposeDraft,
+  updateGmailComposeDraft,
+} from "@/lib/api/compose-drafts";
+import { apiErrorMessage } from "@/lib/http-error";
+
+export function ComposeSurface() {
+  const [state, dispatch] = useReducer(
+    composeDraftReducer,
+    undefined,
+    () => createComposeDraftState(uuidv4()),
+  );
+  const isSaving = state.status === "saving";
+  const isSaved = state.status === "saved";
+
+  function handleEdit(
+    field: "recipients" | "subject" | "body",
+    value: string,
+  ): void {
+    dispatch({ type: "edit", field, value, idempotencyKey: uuidv4() });
+  }
+
+  async function handleSave(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault();
+    const validation = validateGmailComposeDraftFields({
+      recipients: parseGmailComposeRecipients(state.recipients),
+      subject: state.subject,
+      body: state.body,
+    });
+    if (!validation.valid) {
+      dispatch({ type: "error", message: validation.error.message });
+      return;
+    }
+
+    dispatch({ type: "saving" });
+    const request = {
+      idempotencyKey: state.idempotencyKey,
+      ...validation.fields,
+    };
+    try {
+      const result = state.providerDraft
+        ? await updateGmailComposeDraft(
+            state.providerDraft.providerDraftId,
+            request,
+          )
+        : await createGmailComposeDraft(request);
+      dispatch({ type: "saved", draft: result.draft });
+    } catch (error) {
+      dispatch({
+        type: "error",
+        message: apiErrorMessage(error, "Invook could not save this draft to Gmail."),
+      });
+    }
+  }
+
+  return (
+    <section className="flex min-h-0 flex-col bg-background">
+      <SurfaceHeader title="New message" />
+      <form
+        className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-6 py-8 sm:px-10"
+        onSubmit={(event) => void handleSave(event)}
+      >
+        <div className="space-y-5">
+          <div className="grid gap-2 sm:grid-cols-[72px_minmax(0,1fr)] sm:items-center">
+            <label htmlFor="compose-recipients" className="text-sm text-muted-foreground">
+              To
+            </label>
+            <Input
+              id="compose-recipients"
+              value={state.recipients}
+              onChange={(event) => handleEdit("recipients", event.target.value)}
+              placeholder="person@example.com, teammate@example.com"
+              autoComplete="off"
+              disabled={isSaving}
+              required
+            />
+          </div>
+          <div className="grid gap-2 sm:grid-cols-[72px_minmax(0,1fr)] sm:items-center">
+            <label htmlFor="compose-subject" className="text-sm text-muted-foreground">
+              Subject
+            </label>
+            <Input
+              id="compose-subject"
+              value={state.subject}
+              onChange={(event) => handleEdit("subject", event.target.value)}
+              maxLength={GMAIL_COMPOSE_MAX_SUBJECT_LENGTH}
+              disabled={isSaving}
+            />
+          </div>
+        </div>
+
+        <label htmlFor="compose-body" className="sr-only">
+          Message body
+        </label>
+        <Textarea
+          id="compose-body"
+          value={state.body}
+          onChange={(event) => handleEdit("body", event.target.value)}
+          placeholder="Write your message"
+          maxLength={GMAIL_COMPOSE_MAX_BODY_LENGTH}
+          disabled={isSaving}
+          required
+          className="mt-6 min-h-64 flex-1 resize-none bg-card/35 px-4 py-4 text-[15px] leading-7"
+        />
+
+        <div className="mt-5 flex flex-wrap items-center justify-between gap-4">
+          <div className="max-w-lg text-xs leading-5 text-muted-foreground">
+            <p>Sending isn&apos;t available here. This action only saves a draft in Gmail.</p>
+            {state.message ? (
+              <p
+                className={state.status === "error" ? "mt-1 text-destructive" : "mt-1 text-success"}
+                role={state.status === "error" ? "alert" : "status"}
+                aria-live="polite"
+              >
+                {state.message}
+              </p>
+            ) : null}
+          </div>
+          <Button type="submit" disabled={isSaving || isSaved}>
+            <HugeiconsIcon
+              icon={isSaved ? CheckmarkCircle02Icon : MailAdd01Icon}
+              size={14}
+            />
+            {isSaving
+              ? "Saving to Gmail…"
+              : isSaved
+                ? "Saved to Gmail drafts"
+                : state.providerDraft
+                  ? "Update Gmail draft"
+                  : "Save to Gmail drafts"}
+          </Button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/components/mail/surface-header.tsx
+++ b/apps/web/src/components/mail/surface-header.tsx
@@ -1,0 +1,22 @@
+import { ArrowLeft02Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+export interface SurfaceHeaderProps {
+  title: string;
+}
+
+export function SurfaceHeader({ title }: SurfaceHeaderProps) {
+  return (
+    <header className="flex h-15 shrink-0 items-center gap-2 border-b border-border/45 px-4">
+      <Button asChild variant="ghost" size="icon-sm">
+        <Link href="/mail" aria-label="Return to mail">
+          <HugeiconsIcon icon={ArrowLeft02Icon} size={15} />
+        </Link>
+      </Button>
+      <h1 className="text-[15px] font-semibold tracking-[-0.02em]">{title}</h1>
+    </header>
+  );
+}

--- a/apps/web/src/components/mail/workspace-surface.tsx
+++ b/apps/web/src/components/mail/workspace-surface.tsx
@@ -1,7 +1,5 @@
 import {
-  ArrowLeft02Icon,
   Attachment01Icon,
-  PencilEdit01Icon,
   Search02Icon,
   WorkflowSquare01Icon,
 } from "@hugeicons/core-free-icons";
@@ -18,25 +16,7 @@ import { MemorySettings } from "@/components/settings/memory-settings";
 import { LabelSettings } from "@/components/settings/label-settings";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Separator } from "@/components/ui/separator";
-import { Textarea } from "@/components/ui/textarea";
-
-interface SurfaceHeaderProps {
-  title: string;
-}
-
-function SurfaceHeader({ title }: SurfaceHeaderProps) {
-  return (
-    <header className="flex h-15 shrink-0 items-center gap-2 border-b border-border/45 px-4">
-      <Button asChild variant="ghost" size="icon-sm">
-        <Link href="/mail" aria-label="Return to mail">
-          <HugeiconsIcon icon={ArrowLeft02Icon} size={15} />
-        </Link>
-      </Button>
-      <h1 className="text-[15px] font-semibold tracking-[-0.02em]">{title}</h1>
-    </header>
-  );
-}
+import { SurfaceHeader } from "@/components/mail/surface-header";
 
 export function SearchSurface() {
   return (
@@ -133,39 +113,6 @@ export function SearchResultsSurface({
             ))}
           </div>
         )}
-      </div>
-    </section>
-  );
-}
-
-export function ComposeSurface() {
-  return (
-    <section className="flex min-h-0 flex-col bg-background">
-      <SurfaceHeader title="New message" />
-      <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col px-6 py-8 sm:px-10">
-        <div className="flex items-center gap-3 text-sm">
-          <span className="w-14 text-muted-foreground">To</span>
-          <Input aria-label="Recipients" className="h-8 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0" />
-        </div>
-        <Separator />
-        <div className="flex items-center gap-3 text-sm">
-          <span className="w-14 text-muted-foreground">Subject</span>
-          <Input aria-label="Subject" className="h-8 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0" />
-        </div>
-        <Separator />
-        <Textarea
-          aria-label="Message body"
-          className="min-h-64 flex-1 resize-none border-0 bg-transparent px-0 py-6 text-[15px] leading-7 shadow-none focus-visible:ring-0"
-        />
-        <div className="flex items-center justify-between border-t pt-3">
-          <p className="text-xs text-muted-foreground">
-            Gmail draft creation and sending are not connected in this UI slice.
-          </p>
-          <Button disabled>
-            <HugeiconsIcon icon={PencilEdit01Icon} size={14} />
-            Send
-          </Button>
-        </div>
       </div>
     </section>
   );

--- a/apps/web/src/lib/api/compose-drafts.ts
+++ b/apps/web/src/lib/api/compose-drafts.ts
@@ -1,0 +1,27 @@
+import type {
+  CreateGmailComposeDraftRequest,
+  GmailComposeDraftResponse,
+  UpdateGmailComposeDraftRequest,
+} from "@invook/contracts";
+import axios from "axios";
+
+export async function createGmailComposeDraft(
+  request: CreateGmailComposeDraftRequest,
+): Promise<GmailComposeDraftResponse> {
+  const response = await axios.post<GmailComposeDraftResponse>(
+    "/v1/gmail/compose-drafts",
+    request,
+  );
+  return response.data;
+}
+
+export async function updateGmailComposeDraft(
+  providerDraftId: string,
+  request: UpdateGmailComposeDraftRequest,
+): Promise<GmailComposeDraftResponse> {
+  const response = await axios.put<GmailComposeDraftResponse>(
+    `/v1/gmail/compose-drafts/${encodeURIComponent(providerDraftId)}`,
+    request,
+  );
+  return response.data;
+}

--- a/docs/product-requirements.md
+++ b/docs/product-requirements.md
@@ -152,6 +152,8 @@ Unrelated contact memory is never supplied. The model returns the draft, the IDs
 
 Sending is outside the current slice. The UI may explicitly save an AI reply as a Gmail Draft; that creates a separate provider resource and keeps the AI draft/evidence unchanged. It must not imply that a message was sent.
 
+New-message Compose accepts explicit recipient email addresses, subject, and plain-text body, and saves or updates a Gmail Draft. Gmail is written first; Invook then schedules stored-cursor history catch-up so the provider-owned draft converges into the local replica. Compose does not expose a Send action in this phase.
+
 ## Feedback
 
 Feedback is a core input, not an analytics afterthought.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -7,9 +7,12 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "test": "node --import tsx --test src/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsx": "^4.20.0",
     "typescript": "^5.9.0"
   }
 }

--- a/packages/contracts/src/gmail-compose.test.ts
+++ b/packages/contracts/src/gmail-compose.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseGmailComposeRecipients,
+  validateGmailComposeDraftFields,
+} from "./gmail-compose";
+
+test("compose recipients are parsed as an explicit comma-separated list", () => {
+  assert.deepEqual(
+    parseGmailComposeRecipients("first@example.com, second@example.com"),
+    ["first@example.com", "second@example.com"],
+  );
+  assert.deepEqual(parseGmailComposeRecipients("  "), []);
+});
+
+test("compose validation rejects invalid and duplicate recipients", () => {
+  const invalid = validateGmailComposeDraftFields({
+    recipients: ["not-an-email"],
+    subject: "Subject",
+    body: "Body",
+  });
+  assert.deepEqual(invalid, {
+    valid: false,
+    error: {
+      field: "recipients",
+      message: "Enter valid email addresses separated by commas.",
+    },
+  });
+
+  const duplicate = validateGmailComposeDraftFields({
+    recipients: ["person@example.com", "PERSON@example.com"],
+    subject: "Subject",
+    body: "Body",
+  });
+  assert.equal(duplicate.valid, false);
+  if (!duplicate.valid) assert.equal(duplicate.error.field, "recipients");
+});
+
+test("compose validation rejects header injection and empty bodies", () => {
+  const injected = validateGmailComposeDraftFields({
+    recipients: ["person@example.com"],
+    subject: "Subject\r\nBcc: hidden@example.com",
+    body: "Body",
+  });
+  assert.equal(injected.valid, false);
+  if (!injected.valid) assert.equal(injected.error.field, "subject");
+
+  const emptyBody = validateGmailComposeDraftFields({
+    recipients: ["person@example.com"],
+    subject: "",
+    body: " \n ",
+  });
+  assert.equal(emptyBody.valid, false);
+  if (!emptyBody.valid) assert.equal(emptyBody.error.field, "body");
+});
+
+test("compose validation preserves valid user-authored subject and body text", () => {
+  const result = validateGmailComposeDraftFields({
+    recipients: [" person@example.com "],
+    subject: "Quarterly update",
+    body: "First line\nSecond line",
+  });
+  assert.deepEqual(result, {
+    valid: true,
+    fields: {
+      recipients: ["person@example.com"],
+      subject: "Quarterly update",
+      body: "First line\nSecond line",
+    },
+  });
+});

--- a/packages/contracts/src/gmail-compose.ts
+++ b/packages/contracts/src/gmail-compose.ts
@@ -1,0 +1,139 @@
+export const GMAIL_COMPOSE_MAX_RECIPIENTS = 50;
+export const GMAIL_COMPOSE_MAX_SUBJECT_LENGTH = 998;
+export const GMAIL_COMPOSE_MAX_BODY_LENGTH = 10_000;
+
+export type GmailComposeDraftFields = {
+  recipients: string[];
+  subject: string;
+  body: string;
+};
+
+export type GmailComposeDraftValidationError = {
+  field: "recipients" | "subject" | "body";
+  message: string;
+};
+
+export type GmailComposeDraftValidationResult =
+  | { valid: true; fields: GmailComposeDraftFields }
+  | { valid: false; error: GmailComposeDraftValidationError };
+
+export type CreateGmailComposeDraftRequest = GmailComposeDraftFields & {
+  idempotencyKey: string;
+};
+
+export type UpdateGmailComposeDraftRequest = CreateGmailComposeDraftRequest;
+
+export type GmailComposeDraft = {
+  providerDraftId: string;
+  providerMessageId: string;
+  providerThreadId: string;
+};
+
+export type GmailComposeDraftResponse = {
+  draft: GmailComposeDraft;
+  stepId: string;
+};
+
+const EMAIL_ADDRESS_PATTERN =
+  /^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9.-]+$/;
+const HEADER_CONTROL_PATTERN = /[\u0000-\u001f\u007f]/;
+
+export function parseGmailComposeRecipients(value: string): string[] {
+  if (!value.trim()) return [];
+  return value.split(",").map((recipient) => recipient.trim());
+}
+
+export function validateGmailComposeDraftFields(
+  input: GmailComposeDraftFields,
+): GmailComposeDraftValidationResult {
+  if (
+    input.recipients.length === 0 ||
+    input.recipients.some((recipient) => !recipient)
+  ) {
+    return {
+      valid: false,
+      error: {
+        field: "recipients",
+        message: "Enter at least one recipient email address.",
+      },
+    };
+  }
+  if (input.recipients.length > GMAIL_COMPOSE_MAX_RECIPIENTS) {
+    return {
+      valid: false,
+      error: {
+        field: "recipients",
+        message: `Enter no more than ${GMAIL_COMPOSE_MAX_RECIPIENTS} recipients.`,
+      },
+    };
+  }
+
+  const normalizedRecipients = input.recipients.map((recipient) => recipient.trim());
+  if (
+    normalizedRecipients.some(
+      (recipient) =>
+        recipient.length > 254 ||
+        HEADER_CONTROL_PATTERN.test(recipient) ||
+        !EMAIL_ADDRESS_PATTERN.test(recipient),
+    )
+  ) {
+    return {
+      valid: false,
+      error: {
+        field: "recipients",
+        message: "Enter valid email addresses separated by commas.",
+      },
+    };
+  }
+
+  const uniqueRecipients = new Set(
+    normalizedRecipients.map((recipient) => recipient.toLocaleLowerCase("en-US")),
+  );
+  if (uniqueRecipients.size !== normalizedRecipients.length) {
+    return {
+      valid: false,
+      error: {
+        field: "recipients",
+        message: "Remove duplicate recipient email addresses.",
+      },
+    };
+  }
+
+  if (
+    input.subject.length > GMAIL_COMPOSE_MAX_SUBJECT_LENGTH ||
+    HEADER_CONTROL_PATTERN.test(input.subject)
+  ) {
+    return {
+      valid: false,
+      error: {
+        field: "subject",
+        message: `Subject must be ${GMAIL_COMPOSE_MAX_SUBJECT_LENGTH} characters or fewer and contain no line breaks.`,
+      },
+    };
+  }
+
+  if (!input.body.trim()) {
+    return {
+      valid: false,
+      error: { field: "body", message: "Enter a message body." },
+    };
+  }
+  if (input.body.length > GMAIL_COMPOSE_MAX_BODY_LENGTH) {
+    return {
+      valid: false,
+      error: {
+        field: "body",
+        message: `Message body must be ${GMAIL_COMPOSE_MAX_BODY_LENGTH.toLocaleString("en-US")} characters or fewer.`,
+      },
+    };
+  }
+
+  return {
+    valid: true,
+    fields: {
+      recipients: normalizedRecipients,
+      subject: input.subject,
+      body: input.body,
+    },
+  };
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./gmail-compose";
+
 export type AccountSyncStage = "pending" | "running" | "complete" | "failed";
 
 export const MAIL_EMBEDDING_DIMENSIONS = 1_536;

--- a/packages/database/drizzle/0018_left_gorgon.sql
+++ b/packages/database/drizzle/0018_left_gorgon.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "gmail_draft_write_operations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"account_id" uuid NOT NULL,
+	"operation" text NOT NULL,
+	"status" text NOT NULL,
+	"idempotency_key" uuid NOT NULL,
+	"request_fingerprint" text NOT NULL,
+	"provider_draft_id" text,
+	"provider_message_id" text,
+	"provider_thread_id" text,
+	"completed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "gmail_draft_write_operations_operation_check" CHECK ("gmail_draft_write_operations"."operation" in ('create', 'update')),
+	CONSTRAINT "gmail_draft_write_operations_status_check" CHECK ("gmail_draft_write_operations"."status" in ('pending', 'complete')),
+	CONSTRAINT "gmail_draft_write_operations_result_check" CHECK (("gmail_draft_write_operations"."status" = 'pending' and "gmail_draft_write_operations"."provider_draft_id" is null and "gmail_draft_write_operations"."provider_message_id" is null and "gmail_draft_write_operations"."provider_thread_id" is null and "gmail_draft_write_operations"."completed_at" is null) or ("gmail_draft_write_operations"."status" = 'complete' and "gmail_draft_write_operations"."provider_draft_id" is not null and "gmail_draft_write_operations"."provider_message_id" is not null and "gmail_draft_write_operations"."provider_thread_id" is not null and "gmail_draft_write_operations"."completed_at" is not null))
+);
+--> statement-breakpoint
+ALTER TABLE "gmail_draft_write_operations" ADD CONSTRAINT "gmail_draft_write_operations_user_id_profiles_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."profiles"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "gmail_draft_write_operations" ADD CONSTRAINT "gmail_draft_write_operations_account_id_connected_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."connected_accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "gmail_draft_write_operations_user_key_idx" ON "gmail_draft_write_operations" USING btree ("user_id","idempotency_key");--> statement-breakpoint
+CREATE INDEX "gmail_draft_write_operations_account_status_idx" ON "gmail_draft_write_operations" USING btree ("account_id","status","created_at");

--- a/packages/database/drizzle/meta/0018_snapshot.json
+++ b/packages/database/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,5880 @@
+{
+  "id": "305472e1-e5c2-4d72-bc62-937fade5f148",
+  "prevId": "4c4b103f-bcad-4d72-88b4-ea2135aeaf72",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_secrets": {
+      "name": "account_secrets",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refreshed_at": {
+          "name": "refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_secrets_account_id_connected_accounts_id_fk": {
+          "name": "account_secrets_account_id_connected_accounts_id_fk",
+          "tableFrom": "account_secrets",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_user_created_idx": {
+          "name": "audit_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_user_id_profiles_id_fk": {
+          "name": "audit_events_user_id_profiles_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_events_account_id_connected_accounts_id_fk": {
+          "name": "audit_events_account_id_connected_accounts_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connected_accounts": {
+      "name": "connected_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gmail'"
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "memory_acknowledged_at": {
+          "name": "memory_acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"mailSync\":\"pending\",\"indexing\":\"pending\",\"memory\":\"pending\"}'::jsonb"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connected_accounts_provider_identity_idx": {
+          "name": "connected_accounts_provider_identity_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connected_accounts_user_created_idx": {
+          "name": "connected_accounts_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_profiles_id_fk": {
+          "name": "connected_accounts_user_id_profiles_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connected_accounts_provider_check": {
+          "name": "connected_accounts_provider_check",
+          "value": "\"connected_accounts\".\"provider\" = 'gmail'"
+        },
+        "connected_accounts_status_check": {
+          "name": "connected_accounts_status_check",
+          "value": "\"connected_accounts\".\"status\" in ('connected', 'reconnect_required', 'disconnected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editing'"
+        },
+        "generated_text": {
+          "name": "generated_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_text": {
+          "name": "current_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "final_sent_text": {
+          "name": "final_sent_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_memory_ids": {
+          "name": "used_memory_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::uuid[]"
+        },
+        "generation_metadata": {
+          "name": "generation_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "edit_signals": {
+          "name": "edit_signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "feedback_version": {
+          "name": "feedback_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_feedback_at": {
+          "name": "last_feedback_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drafts_user_updated_idx": {
+          "name": "drafts_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drafts_user_id_profiles_id_fk": {
+          "name": "drafts_user_id_profiles_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_account_id_connected_accounts_id_fk": {
+          "name": "drafts_account_id_connected_accounts_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_thread_id_threads_id_fk": {
+          "name": "drafts_thread_id_threads_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "drafts_status_check": {
+          "name": "drafts_status_check",
+          "value": "\"drafts\".\"status\" in ('editing', 'sent', 'discarded', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.embedding_batch_submissions": {
+      "name": "embedding_batch_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_step_id": {
+          "name": "workflow_step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai'"
+        },
+        "provider_batch_id": {
+          "name": "provider_batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_file_id": {
+          "name": "input_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_version": {
+          "name": "index_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "batch_attempt": {
+          "name": "batch_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "has_more": {
+          "name": "has_more",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "embedding_batch_submissions_workflow_step_idx": {
+          "name": "embedding_batch_submissions_workflow_step_idx",
+          "columns": [
+            {
+              "expression": "workflow_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_batch_submissions_provider_batch_idx": {
+          "name": "embedding_batch_submissions_provider_batch_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"embedding_batch_submissions\".\"provider_batch_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_batch_submissions_account_active_idx": {
+          "name": "embedding_batch_submissions_account_active_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"embedding_batch_submissions\".\"status\" in ('preparing', 'submitted')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "embedding_batch_submissions_account_status_idx": {
+          "name": "embedding_batch_submissions_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "embedding_batch_submissions_workflow_step_id_workflow_steps_id_fk": {
+          "name": "embedding_batch_submissions_workflow_step_id_workflow_steps_id_fk",
+          "tableFrom": "embedding_batch_submissions",
+          "tableTo": "workflow_steps",
+          "columnsFrom": [
+            "workflow_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "embedding_batch_submissions_user_id_profiles_id_fk": {
+          "name": "embedding_batch_submissions_user_id_profiles_id_fk",
+          "tableFrom": "embedding_batch_submissions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "embedding_batch_submissions_account_id_connected_accounts_id_fk": {
+          "name": "embedding_batch_submissions_account_id_connected_accounts_id_fk",
+          "tableFrom": "embedding_batch_submissions",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "embedding_batch_submissions_provider_check": {
+          "name": "embedding_batch_submissions_provider_check",
+          "value": "\"embedding_batch_submissions\".\"provider\" = 'openai'"
+        },
+        "embedding_batch_submissions_status_check": {
+          "name": "embedding_batch_submissions_status_check",
+          "value": "\"embedding_batch_submissions\".\"status\" in ('preparing', 'submitted', 'complete', 'failed')"
+        },
+        "embedding_batch_submissions_dimensions_check": {
+          "name": "embedding_batch_submissions_dimensions_check",
+          "value": "\"embedding_batch_submissions\".\"dimensions\" = 1536"
+        },
+        "embedding_batch_submissions_request_count_check": {
+          "name": "embedding_batch_submissions_request_count_check",
+          "value": "\"embedding_batch_submissions\".\"request_count\" > 0"
+        },
+        "embedding_batch_submissions_batch_attempt_check": {
+          "name": "embedding_batch_submissions_batch_attempt_check",
+          "value": "\"embedding_batch_submissions\".\"batch_attempt\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_account_cleanups": {
+      "name": "gmail_account_cleanups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "object_count": {
+          "name": "object_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_account_cleanups_account_idx": {
+          "name": "gmail_account_cleanups_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_account_cleanups_user_created_idx": {
+          "name": "gmail_account_cleanups_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_account_cleanups_user_id_profiles_id_fk": {
+          "name": "gmail_account_cleanups_user_id_profiles_id_fk",
+          "tableFrom": "gmail_account_cleanups",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_account_cleanups_status_check": {
+          "name": "gmail_account_cleanups_status_check",
+          "value": "\"gmail_account_cleanups\".\"status\" in ('queued', 'running', 'complete', 'failed')"
+        },
+        "gmail_account_cleanups_object_count_check": {
+          "name": "gmail_account_cleanups_object_count_check",
+          "value": "\"gmail_account_cleanups\".\"object_count\" is null or \"gmail_account_cleanups\".\"object_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_draft_write_operations": {
+      "name": "gmail_draft_write_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_draft_id": {
+          "name": "provider_draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_draft_write_operations_user_key_idx": {
+          "name": "gmail_draft_write_operations_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_draft_write_operations_account_status_idx": {
+          "name": "gmail_draft_write_operations_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_draft_write_operations_user_id_profiles_id_fk": {
+          "name": "gmail_draft_write_operations_user_id_profiles_id_fk",
+          "tableFrom": "gmail_draft_write_operations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_draft_write_operations_account_id_connected_accounts_id_fk": {
+          "name": "gmail_draft_write_operations_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_draft_write_operations",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_draft_write_operations_operation_check": {
+          "name": "gmail_draft_write_operations_operation_check",
+          "value": "\"gmail_draft_write_operations\".\"operation\" in ('create', 'update')"
+        },
+        "gmail_draft_write_operations_status_check": {
+          "name": "gmail_draft_write_operations_status_check",
+          "value": "\"gmail_draft_write_operations\".\"status\" in ('pending', 'complete')"
+        },
+        "gmail_draft_write_operations_result_check": {
+          "name": "gmail_draft_write_operations_result_check",
+          "value": "(\"gmail_draft_write_operations\".\"status\" = 'pending' and \"gmail_draft_write_operations\".\"provider_draft_id\" is null and \"gmail_draft_write_operations\".\"provider_message_id\" is null and \"gmail_draft_write_operations\".\"provider_thread_id\" is null and \"gmail_draft_write_operations\".\"completed_at\" is null) or (\"gmail_draft_write_operations\".\"status\" = 'complete' and \"gmail_draft_write_operations\".\"provider_draft_id\" is not null and \"gmail_draft_write_operations\".\"provider_message_id\" is not null and \"gmail_draft_write_operations\".\"provider_thread_id\" is not null and \"gmail_draft_write_operations\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_drafts": {
+      "name": "gmail_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_draft_id": {
+          "name": "provider_draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_history_id": {
+          "name": "provider_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_drafts_account_provider_idx": {
+          "name": "gmail_drafts_account_provider_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_drafts_account_thread_idx": {
+          "name": "gmail_drafts_account_thread_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_drafts_user_id_profiles_id_fk": {
+          "name": "gmail_drafts_user_id_profiles_id_fk",
+          "tableFrom": "gmail_drafts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_drafts_account_id_connected_accounts_id_fk": {
+          "name": "gmail_drafts_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_drafts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_drafts_message_id_messages_id_fk": {
+          "name": "gmail_drafts_message_id_messages_id_fk",
+          "tableFrom": "gmail_drafts",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_labels": {
+      "name": "gmail_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_label_id": {
+          "name": "provider_label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_list_visibility": {
+          "name": "message_list_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_list_visibility": {
+          "name": "label_list_visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_labels_account_provider_idx": {
+          "name": "gmail_labels_account_provider_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_labels_account_name_idx": {
+          "name": "gmail_labels_account_name_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_labels_user_id_profiles_id_fk": {
+          "name": "gmail_labels_user_id_profiles_id_fk",
+          "tableFrom": "gmail_labels",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_labels_account_id_connected_accounts_id_fk": {
+          "name": "gmail_labels_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_labels",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_labels_type_check": {
+          "name": "gmail_labels_type_check",
+          "value": "\"gmail_labels\".\"type\" in ('system', 'user')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_message_labels": {
+      "name": "gmail_message_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gmail_label_id": {
+          "name": "gmail_label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_message_labels_message_label_idx": {
+          "name": "gmail_message_labels_message_label_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_message_labels_account_label_idx": {
+          "name": "gmail_message_labels_account_label_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "gmail_label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_message_labels_account_id_connected_accounts_id_fk": {
+          "name": "gmail_message_labels_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_message_labels",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_message_labels_message_id_messages_id_fk": {
+          "name": "gmail_message_labels_message_id_messages_id_fk",
+          "tableFrom": "gmail_message_labels",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_message_labels_gmail_label_id_gmail_labels_id_fk": {
+          "name": "gmail_message_labels_gmail_label_id_gmail_labels_id_fk",
+          "tableFrom": "gmail_message_labels",
+          "tableTo": "gmail_labels",
+          "columnsFrom": [
+            "gmail_label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_message_tombstones": {
+      "name": "gmail_message_tombstones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_history_id": {
+          "name": "provider_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_keys": {
+          "name": "object_keys",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_message_tombstones_account_message_idx": {
+          "name": "gmail_message_tombstones_account_message_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_message_tombstones_account_deleted_idx": {
+          "name": "gmail_message_tombstones_account_deleted_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_message_tombstones_user_id_profiles_id_fk": {
+          "name": "gmail_message_tombstones_user_id_profiles_id_fk",
+          "tableFrom": "gmail_message_tombstones",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_message_tombstones_account_id_connected_accounts_id_fk": {
+          "name": "gmail_message_tombstones_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_message_tombstones",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_push_events": {
+      "name": "gmail_push_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_event_id": {
+          "name": "provider_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_address": {
+          "name": "email_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_history_id": {
+          "name": "notification_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscription": {
+          "name": "subscription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'stored'"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_push_events_provider_event_idx": {
+          "name": "gmail_push_events_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_push_events_account_created_idx": {
+          "name": "gmail_push_events_account_created_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_push_events_account_id_connected_accounts_id_fk": {
+          "name": "gmail_push_events_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_push_events",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_push_events_status_check": {
+          "name": "gmail_push_events_status_check",
+          "value": "\"gmail_push_events\".\"status\" in ('stored', 'processed', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_replica_audits": {
+      "name": "gmail_replica_audits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "provider_message_count": {
+          "name": "provider_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stored_message_count": {
+          "name": "stored_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "missing_message_ids": {
+          "name": "missing_message_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "extra_message_ids": {
+          "name": "extra_message_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_replica_audits_account_created_idx": {
+          "name": "gmail_replica_audits_account_created_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_replica_audits_user_id_profiles_id_fk": {
+          "name": "gmail_replica_audits_user_id_profiles_id_fk",
+          "tableFrom": "gmail_replica_audits",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_replica_audits_account_id_connected_accounts_id_fk": {
+          "name": "gmail_replica_audits_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_replica_audits",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_replica_audits_trigger_check": {
+          "name": "gmail_replica_audits_trigger_check",
+          "value": "\"gmail_replica_audits\".\"trigger\" in ('initial', 'history_expired', 'watch_renewal', 'manual')"
+        },
+        "gmail_replica_audits_status_check": {
+          "name": "gmail_replica_audits_status_check",
+          "value": "\"gmail_replica_audits\".\"status\" in ('running', 'complete', 'repairing', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_replica_states": {
+      "name": "gmail_replica_states",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "initial_history_id": {
+          "name": "initial_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_cursor": {
+          "name": "history_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_history_at": {
+          "name": "last_history_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_audit_at": {
+          "name": "last_audit_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_replica_states_state_idx": {
+          "name": "gmail_replica_states_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_replica_states_account_id_connected_accounts_id_fk": {
+          "name": "gmail_replica_states_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_replica_states",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_replica_states_state_check": {
+          "name": "gmail_replica_states_state_check",
+          "value": "\"gmail_replica_states\".\"state\" in ('pending', 'snapshotting', 'replaying', 'auditing', 'ready', 'repairing', 'failed', 'deleting')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_sync_items": {
+      "name": "gmail_sync_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_sync_items_run_message_idx": {
+          "name": "gmail_sync_items_run_message_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_sync_items_run_status_idx": {
+          "name": "gmail_sync_items_run_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_sync_items_run_id_mail_sync_runs_id_fk": {
+          "name": "gmail_sync_items_run_id_mail_sync_runs_id_fk",
+          "tableFrom": "gmail_sync_items",
+          "tableTo": "mail_sync_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_sync_items_status_check": {
+          "name": "gmail_sync_items_status_check",
+          "value": "\"gmail_sync_items\".\"status\" in ('queued', 'running', 'complete', 'failed')"
+        },
+        "gmail_sync_items_attempts_check": {
+          "name": "gmail_sync_items_attempts_check",
+          "value": "\"gmail_sync_items\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_sync_pages": {
+      "name": "gmail_sync_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_number": {
+          "name": "page_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_token": {
+          "name": "page_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_page_token": {
+          "name": "next_page_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovered_message_count": {
+          "name": "discovered_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_sync_pages_run_number_idx": {
+          "name": "gmail_sync_pages_run_number_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_sync_pages_run_id_mail_sync_runs_id_fk": {
+          "name": "gmail_sync_pages_run_id_mail_sync_runs_id_fk",
+          "tableFrom": "gmail_sync_pages",
+          "tableTo": "mail_sync_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_sync_pages_number_check": {
+          "name": "gmail_sync_pages_number_check",
+          "value": "\"gmail_sync_pages\".\"page_number\" > 0"
+        },
+        "gmail_sync_pages_message_count_check": {
+          "name": "gmail_sync_pages_message_count_check",
+          "value": "\"gmail_sync_pages\".\"discovered_message_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_watch_states": {
+      "name": "gmail_watch_states",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_name": {
+          "name": "topic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_id": {
+          "name": "history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_at": {
+          "name": "expiration_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_watch_states_expiration_idx": {
+          "name": "gmail_watch_states_expiration_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_watch_states_account_id_connected_accounts_id_fk": {
+          "name": "gmail_watch_states_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_watch_states",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_watch_states_status_check": {
+          "name": "gmail_watch_states_status_check",
+          "value": "\"gmail_watch_states\".\"status\" in ('active', 'stopped', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_key": {
+          "name": "system_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "analysis_state": {
+          "name": "analysis_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "last_analyzed_at": {
+          "name": "last_analyzed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labels_account_name_idx": {
+          "name": "labels_account_name_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_account_system_key_idx": {
+          "name": "labels_account_system_key_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_account_created_idx": {
+          "name": "labels_account_created_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labels_user_id_profiles_id_fk": {
+          "name": "labels_user_id_profiles_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "labels_account_id_connected_accounts_id_fk": {
+          "name": "labels_account_id_connected_accounts_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "labels_name_check": {
+          "name": "labels_name_check",
+          "value": "char_length(btrim(\"labels\".\"name\")) > 0"
+        },
+        "labels_normalized_name_check": {
+          "name": "labels_normalized_name_check",
+          "value": "char_length(btrim(\"labels\".\"normalized_name\")) > 0"
+        },
+        "labels_description_check": {
+          "name": "labels_description_check",
+          "value": "char_length(btrim(\"labels\".\"description\")) > 0"
+        },
+        "labels_system_key_check": {
+          "name": "labels_system_key_check",
+          "value": "\"labels\".\"system_key\" is null or \"labels\".\"system_key\" in ('important', 'travel', 'pitch', 'newsletter')"
+        },
+        "labels_definition_version_check": {
+          "name": "labels_definition_version_check",
+          "value": "\"labels\".\"definition_version\" > 0"
+        },
+        "labels_analysis_state_check": {
+          "name": "labels_analysis_state_check",
+          "value": "\"labels\".\"analysis_state\" in ('pending', 'running', 'complete', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mail_sync_runs": {
+      "name": "mail_sync_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "starting_history_cursor": {
+          "name": "starting_history_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_history_cursor": {
+          "name": "final_history_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovery_complete": {
+          "name": "discovery_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "discovered_message_count": {
+          "name": "discovered_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_message_count": {
+          "name": "processed_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_message_count": {
+          "name": "failed_message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_sync_runs_idempotency_key_idx": {
+          "name": "mail_sync_runs_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_sync_runs_single_active_account_idx": {
+          "name": "mail_sync_runs_single_active_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mail_sync_runs\".\"status\" in ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_sync_runs_account_created_idx": {
+          "name": "mail_sync_runs_account_created_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_sync_runs_user_id_profiles_id_fk": {
+          "name": "mail_sync_runs_user_id_profiles_id_fk",
+          "tableFrom": "mail_sync_runs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_sync_runs_account_id_connected_accounts_id_fk": {
+          "name": "mail_sync_runs_account_id_connected_accounts_id_fk",
+          "tableFrom": "mail_sync_runs",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mail_sync_runs_status_check": {
+          "name": "mail_sync_runs_status_check",
+          "value": "\"mail_sync_runs\".\"status\" in ('queued', 'running', 'complete', 'failed', 'superseded')"
+        },
+        "mail_sync_runs_page_count_check": {
+          "name": "mail_sync_runs_page_count_check",
+          "value": "\"mail_sync_runs\".\"page_count\" >= 0"
+        },
+        "mail_sync_runs_message_counts_check": {
+          "name": "mail_sync_runs_message_counts_check",
+          "value": "\"mail_sync_runs\".\"discovered_message_count\" >= 0 and \"mail_sync_runs\".\"processed_message_count\" >= 0 and \"mail_sync_runs\".\"failed_message_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mailbox_action_proposals": {
+      "name": "mailbox_action_proposals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "gmail_label_id": {
+          "name": "gmail_label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_label_id": {
+          "name": "provider_label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gmail_label_name": {
+          "name": "gmail_label_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_step_id": {
+          "name": "workflow_step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mailbox_action_proposals_idempotency_idx": {
+          "name": "mailbox_action_proposals_idempotency_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailbox_action_proposals_user_created_idx": {
+          "name": "mailbox_action_proposals_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailbox_action_proposals_account_status_idx": {
+          "name": "mailbox_action_proposals_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mailbox_action_proposals_user_id_profiles_id_fk": {
+          "name": "mailbox_action_proposals_user_id_profiles_id_fk",
+          "tableFrom": "mailbox_action_proposals",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mailbox_action_proposals_account_id_connected_accounts_id_fk": {
+          "name": "mailbox_action_proposals_account_id_connected_accounts_id_fk",
+          "tableFrom": "mailbox_action_proposals",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mailbox_action_proposals_gmail_label_id_gmail_labels_id_fk": {
+          "name": "mailbox_action_proposals_gmail_label_id_gmail_labels_id_fk",
+          "tableFrom": "mailbox_action_proposals",
+          "tableTo": "gmail_labels",
+          "columnsFrom": [
+            "gmail_label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mailbox_action_proposals_workflow_step_id_workflow_steps_id_fk": {
+          "name": "mailbox_action_proposals_workflow_step_id_workflow_steps_id_fk",
+          "tableFrom": "mailbox_action_proposals",
+          "tableTo": "workflow_steps",
+          "columnsFrom": [
+            "workflow_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mailbox_action_proposals_operation_check": {
+          "name": "mailbox_action_proposals_operation_check",
+          "value": "\"mailbox_action_proposals\".\"operation\" in ('archive', 'mark_read', 'mark_unread', 'trash', 'apply_gmail_label', 'remove_gmail_label', 'save_draft_to_gmail')"
+        },
+        "mailbox_action_proposals_status_check": {
+          "name": "mailbox_action_proposals_status_check",
+          "value": "\"mailbox_action_proposals\".\"status\" in ('pending', 'executing', 'completed', 'partial_failure', 'failed', 'cancelled')"
+        },
+        "mailbox_action_proposals_label_check": {
+          "name": "mailbox_action_proposals_label_check",
+          "value": "(\"mailbox_action_proposals\".\"operation\" in ('apply_gmail_label', 'remove_gmail_label') and \"mailbox_action_proposals\".\"provider_label_id\" is not null and \"mailbox_action_proposals\".\"gmail_label_name\" is not null) or (\"mailbox_action_proposals\".\"operation\" not in ('apply_gmail_label', 'remove_gmail_label') and \"mailbox_action_proposals\".\"provider_label_id\" is null and \"mailbox_action_proposals\".\"gmail_label_name\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mailbox_action_targets": {
+      "name": "mailbox_action_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_updated_at": {
+          "name": "expected_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_evidence": {
+          "name": "provider_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mailbox_action_targets_proposal_message_idx": {
+          "name": "mailbox_action_targets_proposal_message_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mailbox_action_targets\".\"message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailbox_action_targets_proposal_draft_idx": {
+          "name": "mailbox_action_targets_proposal_draft_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mailbox_action_targets\".\"draft_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailbox_action_targets_proposal_status_idx": {
+          "name": "mailbox_action_targets_proposal_status_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mailbox_action_targets_proposal_id_mailbox_action_proposals_id_fk": {
+          "name": "mailbox_action_targets_proposal_id_mailbox_action_proposals_id_fk",
+          "tableFrom": "mailbox_action_targets",
+          "tableTo": "mailbox_action_proposals",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mailbox_action_targets_user_id_profiles_id_fk": {
+          "name": "mailbox_action_targets_user_id_profiles_id_fk",
+          "tableFrom": "mailbox_action_targets",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mailbox_action_targets_account_id_connected_accounts_id_fk": {
+          "name": "mailbox_action_targets_account_id_connected_accounts_id_fk",
+          "tableFrom": "mailbox_action_targets",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mailbox_action_targets_kind_check": {
+          "name": "mailbox_action_targets_kind_check",
+          "value": "(\"mailbox_action_targets\".\"message_id\" is not null and \"mailbox_action_targets\".\"draft_id\" is null and \"mailbox_action_targets\".\"provider_message_id\" is not null) or (\"mailbox_action_targets\".\"message_id\" is null and \"mailbox_action_targets\".\"draft_id\" is not null and \"mailbox_action_targets\".\"provider_message_id\" is null)"
+        },
+        "mailbox_action_targets_status_check": {
+          "name": "mailbox_action_targets_status_check",
+          "value": "\"mailbox_action_targets\".\"status\" in ('pending', 'executing', 'completed', 'failed', 'stale')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mailbox_change_events": {
+      "name": "mailbox_change_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mailbox_change_events_account_created_idx": {
+          "name": "mailbox_change_events_account_created_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mailbox_change_events_user_id_profiles_id_fk": {
+          "name": "mailbox_change_events_user_id_profiles_id_fk",
+          "tableFrom": "mailbox_change_events",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mailbox_change_events_account_id_connected_accounts_id_fk": {
+          "name": "mailbox_change_events_account_id_connected_accounts_id_fk",
+          "tableFrom": "mailbox_change_events",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mailbox_change_events_type_check": {
+          "name": "mailbox_change_events_type_check",
+          "value": "\"mailbox_change_events\".\"change_type\" in ('replica_ready', 'history_applied', 'repair_complete', 'drafts_changed', 'labels_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.memory_deletions": {
+      "name": "memory_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_deletions_account_fingerprint_idx": {
+          "name": "memory_deletions_account_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_deletions_user_deleted_idx": {
+          "name": "memory_deletions_user_deleted_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_deletions_user_id_profiles_id_fk": {
+          "name": "memory_deletions_user_id_profiles_id_fk",
+          "tableFrom": "memory_deletions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_deletions_account_id_connected_accounts_id_fk": {
+          "name": "memory_deletions_account_id_connected_accounts_id_fk",
+          "tableFrom": "memory_deletions",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_deletions_type_check": {
+          "name": "memory_deletions_type_check",
+          "value": "\"memory_deletions\".\"memory_type\" in ('preference', 'contact', 'scheduling')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.memory_entries": {
+      "name": "memory_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_message_ids": {
+          "name": "evidence_message_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::uuid[]"
+        },
+        "evidence_draft_ids": {
+          "name": "evidence_draft_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::uuid[]"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_entries_account_fingerprint_idx": {
+          "name": "memory_entries_account_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_entries_account_type_contact_idx": {
+          "name": "memory_entries_account_type_contact_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_entries_user_id_profiles_id_fk": {
+          "name": "memory_entries_user_id_profiles_id_fk",
+          "tableFrom": "memory_entries",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_entries_account_id_connected_accounts_id_fk": {
+          "name": "memory_entries_account_id_connected_accounts_id_fk",
+          "tableFrom": "memory_entries",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_entries_type_check": {
+          "name": "memory_entries_type_check",
+          "value": "\"memory_entries\".\"memory_type\" in ('preference', 'contact', 'scheduling')"
+        },
+        "memory_entries_source_check": {
+          "name": "memory_entries_source_check",
+          "value": "\"memory_entries\".\"source\" in ('user', 'inferred', 'feedback')"
+        },
+        "memory_entries_contact_check": {
+          "name": "memory_entries_contact_check",
+          "value": "(\"memory_entries\".\"memory_type\" = 'contact' and \"memory_entries\".\"contact_email\" is not null) or (\"memory_entries\".\"memory_type\" <> 'contact' and \"memory_entries\".\"contact_email\" is null)"
+        },
+        "memory_entries_statement_check": {
+          "name": "memory_entries_statement_check",
+          "value": "char_length(\"memory_entries\".\"statement\") between 3 and 500"
+        },
+        "memory_entries_confidence_check": {
+          "name": "memory_entries_confidence_check",
+          "value": "\"memory_entries\".\"confidence\" is null or \"memory_entries\".\"confidence\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.memory_pending_evidence": {
+      "name": "memory_pending_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_pending_evidence_message_scope_idx": {
+          "name": "memory_pending_evidence_message_scope_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_pending_evidence_account_scope_idx": {
+          "name": "memory_pending_evidence_account_scope_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "schema_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_pending_evidence_user_id_profiles_id_fk": {
+          "name": "memory_pending_evidence_user_id_profiles_id_fk",
+          "tableFrom": "memory_pending_evidence",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_pending_evidence_account_id_connected_accounts_id_fk": {
+          "name": "memory_pending_evidence_account_id_connected_accounts_id_fk",
+          "tableFrom": "memory_pending_evidence",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_pending_evidence_thread_id_threads_id_fk": {
+          "name": "memory_pending_evidence_thread_id_threads_id_fk",
+          "tableFrom": "memory_pending_evidence",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_pending_evidence_message_id_messages_id_fk": {
+          "name": "memory_pending_evidence_message_id_messages_id_fk",
+          "tableFrom": "memory_pending_evidence",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_pending_evidence_scope_check": {
+          "name": "memory_pending_evidence_scope_check",
+          "value": "\"memory_pending_evidence\".\"scope\" in ('global', 'contact')"
+        },
+        "memory_pending_evidence_contact_check": {
+          "name": "memory_pending_evidence_contact_check",
+          "value": "(\"memory_pending_evidence\".\"scope\" = 'global' and \"memory_pending_evidence\".\"contact_email\" = '') or (\"memory_pending_evidence\".\"scope\" = 'contact' and char_length(btrim(\"memory_pending_evidence\".\"contact_email\")) > 0)"
+        },
+        "memory_pending_evidence_schema_version_check": {
+          "name": "memory_pending_evidence_schema_version_check",
+          "value": "\"memory_pending_evidence\".\"schema_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_attachments": {
+      "name": "message_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_attachment_id": {
+          "name": "provider_attachment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_part_path": {
+          "name": "mime_part_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename_search_document": {
+          "name": "filename_search_document",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', regexp_replace(filename, '[_\\.-]+', ' ', 'g'))",
+            "type": "stored"
+          }
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_disposition": {
+          "name": "content_disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_attachments_message_idx": {
+          "name": "message_attachments_message_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_attachments_account_filename_idx": {
+          "name": "message_attachments_account_filename_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_attachments_filename_search_idx": {
+          "name": "message_attachments_filename_search_idx",
+          "columns": [
+            {
+              "expression": "filename_search_document",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_attachments_user_id_profiles_id_fk": {
+          "name": "message_attachments_user_id_profiles_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_attachments_account_id_connected_accounts_id_fk": {
+          "name": "message_attachments_account_id_connected_accounts_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_attachments_message_id_messages_id_fk": {
+          "name": "message_attachments_message_id_messages_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "message_attachments_size_check": {
+          "name": "message_attachments_size_check",
+          "value": "\"message_attachments\".\"size\" is null or \"message_attachments\".\"size\" >= 0"
+        },
+        "message_attachments_content_length_check": {
+          "name": "message_attachments_content_length_check",
+          "value": "\"message_attachments\".\"content_length\" is null or \"message_attachments\".\"content_length\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_embeddings": {
+      "name": "message_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index_version": {
+          "name": "index_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_batch_id": {
+          "name": "provider_batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_embeddings_message_model_version_idx": {
+          "name": "message_embeddings_message_model_version_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_embeddings_account_status_idx": {
+          "name": "message_embeddings_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_embeddings_embedding_hnsw_idx": {
+          "name": "message_embeddings_embedding_hnsw_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"message_embeddings\".\"status\" = 'complete'",
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_embeddings_user_id_profiles_id_fk": {
+          "name": "message_embeddings_user_id_profiles_id_fk",
+          "tableFrom": "message_embeddings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_embeddings_account_id_connected_accounts_id_fk": {
+          "name": "message_embeddings_account_id_connected_accounts_id_fk",
+          "tableFrom": "message_embeddings",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_embeddings_message_id_messages_id_fk": {
+          "name": "message_embeddings_message_id_messages_id_fk",
+          "tableFrom": "message_embeddings",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "message_embeddings_dimensions_check": {
+          "name": "message_embeddings_dimensions_check",
+          "value": "\"message_embeddings\".\"dimensions\" > 0"
+        },
+        "message_embeddings_status_check": {
+          "name": "message_embeddings_status_check",
+          "value": "\"message_embeddings\".\"status\" in ('pending', 'submitted', 'complete', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "provider_history_id": {
+          "name": "provider_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_date": {
+          "name": "internal_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_estimate": {
+          "name": "size_estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_lines": {
+          "name": "header_lines",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_object_key": {
+          "name": "raw_object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_checksum_sha256": {
+          "name": "raw_checksum_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_content_length": {
+          "name": "raw_content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_etag": {
+          "name": "raw_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_memory_eligible": {
+          "name": "is_memory_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excluded_from_memory": {
+          "name": "excluded_from_memory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_document": {
+          "name": "search_document",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(subject, '') || ' ' || coalesce(body_text, ''))",
+            "type": "stored"
+          }
+        },
+        "metadata_search_document": {
+          "name": "metadata_search_document",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(sender->>'raw', '') || ' ' || coalesce(sender->>'email', '') || ' ' || coalesce(recipients::text, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_thread_provider_message_idx": {
+          "name": "messages_thread_provider_message_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_thread_sent_idx": {
+          "name": "messages_thread_sent_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_account_provider_idx": {
+          "name": "messages_account_provider_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_search_idx": {
+          "name": "messages_search_idx",
+          "columns": [
+            {
+              "expression": "search_document",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_metadata_search_idx": {
+          "name": "messages_metadata_search_idx",
+          "columns": [
+            {
+              "expression": "metadata_search_document",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_memory_eligible_idx": {
+          "name": "messages_memory_eligible_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"direction\" = 'outgoing' and \"messages\".\"is_memory_eligible\" and not \"messages\".\"excluded_from_memory\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_user_id_profiles_id_fk": {
+          "name": "messages_user_id_profiles_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_account_id_connected_accounts_id_fk": {
+          "name": "messages_account_id_connected_accounts_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_thread_id_threads_id_fk": {
+          "name": "messages_thread_id_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messages_direction_check": {
+          "name": "messages_direction_check",
+          "value": "\"messages\".\"direction\" in ('incoming', 'outgoing')"
+        },
+        "messages_size_estimate_check": {
+          "name": "messages_size_estimate_check",
+          "value": "\"messages\".\"size_estimate\" is null or \"messages\".\"size_estimate\" >= 0"
+        },
+        "messages_raw_content_length_check": {
+          "name": "messages_raw_content_length_check",
+          "value": "\"messages\".\"raw_content_length\" is null or \"messages\".\"raw_content_length\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_acknowledged_at": {
+          "name": "memory_acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.queue_outbox": {
+      "name": "queue_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_step_id": {
+          "name": "workflow_step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queue_name": {
+          "name": "queue_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_attempts": {
+          "name": "publish_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "queue_outbox_workflow_step_idx": {
+          "name": "queue_outbox_workflow_step_idx",
+          "columns": [
+            {
+              "expression": "workflow_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "queue_outbox_unpublished_idx": {
+          "name": "queue_outbox_unpublished_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"queue_outbox\".\"published_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "queue_outbox_workflow_step_id_workflow_steps_id_fk": {
+          "name": "queue_outbox_workflow_step_id_workflow_steps_id_fk",
+          "tableFrom": "queue_outbox",
+          "tableTo": "workflow_steps",
+          "columnsFrom": [
+            "workflow_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "queue_outbox_publish_attempts_check": {
+          "name": "queue_outbox_publish_attempts_check",
+          "value": "\"queue_outbox\".\"publish_attempts\" >= 0"
+        },
+        "queue_outbox_queue_name_check": {
+          "name": "queue_outbox_queue_name_check",
+          "value": "\"queue_outbox\".\"queue_name\" in ('gmail-pages', 'gmail-messages', 'gmail-control', 'mail-indexing-batch', 'mail-indexing-live', 'mail-memory-submit', 'mail-memory-events', 'mail-memory-feedback', 'mail-label-submit', 'mail-label-events')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.thread_label_analyses": {
+      "name": "thread_label_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analyzed_at": {
+          "name": "analyzed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "thread_label_analyses_thread_label_idx": {
+          "name": "thread_label_analyses_thread_label_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_label_analyses_label_version_idx": {
+          "name": "thread_label_analyses_label_version_idx",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "definition_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_label_analyses_user_id_profiles_id_fk": {
+          "name": "thread_label_analyses_user_id_profiles_id_fk",
+          "tableFrom": "thread_label_analyses",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_label_analyses_account_id_connected_accounts_id_fk": {
+          "name": "thread_label_analyses_account_id_connected_accounts_id_fk",
+          "tableFrom": "thread_label_analyses",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_label_analyses_thread_id_threads_id_fk": {
+          "name": "thread_label_analyses_thread_id_threads_id_fk",
+          "tableFrom": "thread_label_analyses",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_label_analyses_label_id_labels_id_fk": {
+          "name": "thread_label_analyses_label_id_labels_id_fk",
+          "tableFrom": "thread_label_analyses",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "thread_label_analyses_definition_version_check": {
+          "name": "thread_label_analyses_definition_version_check",
+          "value": "\"thread_label_analyses\".\"definition_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.thread_labels": {
+      "name": "thread_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analysis_version": {
+          "name": "analysis_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "thread_labels_thread_label_idx": {
+          "name": "thread_labels_thread_label_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_labels_account_label_state_idx": {
+          "name": "thread_labels_account_label_state_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_labels_user_id_profiles_id_fk": {
+          "name": "thread_labels_user_id_profiles_id_fk",
+          "tableFrom": "thread_labels",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_labels_account_id_connected_accounts_id_fk": {
+          "name": "thread_labels_account_id_connected_accounts_id_fk",
+          "tableFrom": "thread_labels",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_labels_thread_id_threads_id_fk": {
+          "name": "thread_labels_thread_id_threads_id_fk",
+          "tableFrom": "thread_labels",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_labels_label_id_labels_id_fk": {
+          "name": "thread_labels_label_id_labels_id_fk",
+          "tableFrom": "thread_labels",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "thread_labels_source_check": {
+          "name": "thread_labels_source_check",
+          "value": "\"thread_labels\".\"source\" in ('ai', 'user')"
+        },
+        "thread_labels_state_check": {
+          "name": "thread_labels_state_check",
+          "value": "\"thread_labels\".\"state\" in ('applied', 'dismissed')"
+        },
+        "thread_labels_confidence_check": {
+          "name": "thread_labels_confidence_check",
+          "value": "\"thread_labels\".\"confidence\" is null or \"thread_labels\".\"confidence\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "participants": {
+          "name": "participants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "latest_message_at": {
+          "name": "latest_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "content_version": {
+          "name": "content_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "threads_account_provider_thread_idx": {
+          "name": "threads_account_provider_thread_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "threads_user_latest_idx": {
+          "name": "threads_user_latest_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "latest_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "threads_user_id_profiles_id_fk": {
+          "name": "threads_user_id_profiles_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_account_id_connected_accounts_id_fk": {
+          "name": "threads_account_id_connected_accounts_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "threads_message_count_check": {
+          "name": "threads_message_count_check",
+          "value": "\"threads\".\"message_count\" >= 0"
+        },
+        "threads_content_version_check": {
+          "name": "threads_content_version_check",
+          "value": "\"threads\".\"content_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_steps": {
+      "name": "workflow_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_steps_idempotency_key_idx": {
+          "name": "workflow_steps_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_steps_run_created_idx": {
+          "name": "workflow_steps_run_created_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_steps_account_type_created_idx": {
+          "name": "workflow_steps_account_type_created_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_steps_run_id_mail_sync_runs_id_fk": {
+          "name": "workflow_steps_run_id_mail_sync_runs_id_fk",
+          "tableFrom": "workflow_steps",
+          "tableTo": "mail_sync_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_steps_user_id_profiles_id_fk": {
+          "name": "workflow_steps_user_id_profiles_id_fk",
+          "tableFrom": "workflow_steps",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_steps_account_id_connected_accounts_id_fk": {
+          "name": "workflow_steps_account_id_connected_accounts_id_fk",
+          "tableFrom": "workflow_steps",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_steps_status_check": {
+          "name": "workflow_steps_status_check",
+          "value": "\"workflow_steps\".\"status\" in ('queued', 'running', 'complete', 'failed')"
+        },
+        "workflow_steps_attempts_check": {
+          "name": "workflow_steps_attempts_check",
+          "value": "\"workflow_steps\".\"attempts\" >= 0"
+        },
+        "workflow_steps_max_attempts_check": {
+          "name": "workflow_steps_max_attempts_check",
+          "value": "\"workflow_steps\".\"max_attempts\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1786623336197,
       "tag": "0017_charming_jigsaw",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1786630851933,
+      "tag": "0018_left_gorgon",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/gmail-draft-writes.test.ts
+++ b/packages/database/src/gmail-draft-writes.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { count, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { v4 as uuidv4 } from "uuid";
+
+import {
+  beginGmailDraftWrite,
+  completeGmailDraftWrite,
+  GmailDraftWriteConflictError,
+} from "./gmail-draft-writes";
+import { enqueueGmailHistoryCatchup } from "./replica";
+import {
+  connectedAccounts,
+  profiles,
+  workflowSteps,
+} from "./schema";
+import * as schema from "./schema";
+
+const testDatabaseUrl = process.env.TEST_DATABASE_URL;
+
+test(
+  "Gmail compose writes and their stored-cursor catch-up are idempotent",
+  { skip: !testDatabaseUrl },
+  async () => {
+    if (!testDatabaseUrl) return;
+    const client = postgres(testDatabaseUrl, { max: 1, prepare: false });
+    const database = drizzle(client, { schema });
+    const userId = uuidv4();
+    const accountId = uuidv4();
+    const idempotencyKey = uuidv4();
+    try {
+      await database.insert(profiles).values({ id: userId });
+      await database.insert(connectedAccounts).values({
+        id: accountId,
+        userId,
+        providerAccountId: `provider-${accountId}`,
+        email: "owner@example.com",
+        memoryAcknowledgedAt: new Date(),
+      });
+
+      const input = {
+        userId,
+        accountId,
+        operation: "create" as const,
+        idempotencyKey,
+        requestFingerprint: "fingerprint-one",
+      };
+      const claimed = await beginGmailDraftWrite(input, database);
+      assert.equal(claimed.outcome, "claimed");
+      const pending = await beginGmailDraftWrite(input, database);
+      assert.deepEqual(pending, {
+        outcome: "pending",
+        operationId: claimed.operationId,
+      });
+
+      const result = {
+        providerDraftId: "provider-draft",
+        providerMessageId: "provider-message",
+        providerThreadId: "provider-thread",
+      };
+      await completeGmailDraftWrite(
+        { operationId: claimed.operationId, userId, result },
+        database,
+      );
+      await completeGmailDraftWrite(
+        { operationId: claimed.operationId, userId, result },
+        database,
+      );
+      const completed = await beginGmailDraftWrite(input, database);
+      assert.deepEqual(completed, {
+        outcome: "complete",
+        operationId: claimed.operationId,
+        result,
+      });
+
+      await assert.rejects(
+        beginGmailDraftWrite(
+          { ...input, requestFingerprint: "fingerprint-two" },
+          database,
+        ),
+        GmailDraftWriteConflictError,
+      );
+
+      const catchupInput = {
+        userId,
+        accountId,
+        reason: "provider_write" as const,
+        sourceId: `compose-draft:${claimed.operationId}`,
+      };
+      const firstStepId = await enqueueGmailHistoryCatchup(catchupInput, database);
+      const retryStepId = await enqueueGmailHistoryCatchup(catchupInput, database);
+      assert.equal(retryStepId, firstStepId);
+
+      const [stepCount] = await database
+        .select({ value: count(workflowSteps.id) })
+        .from(workflowSteps)
+        .where(eq(workflowSteps.id, firstStepId));
+      assert.equal(stepCount?.value, 1);
+    } finally {
+      await database.delete(profiles).where(eq(profiles.id, userId));
+      await client.end();
+    }
+  },
+);

--- a/packages/database/src/gmail-draft-writes.ts
+++ b/packages/database/src/gmail-draft-writes.ts
@@ -1,0 +1,174 @@
+import { and, eq } from "drizzle-orm";
+
+import {
+  getDatabase,
+  type Database,
+} from "./client";
+import { gmailDraftWriteOperations } from "./schema";
+
+export type GmailDraftWriteOperation = "create" | "update";
+
+export type GmailDraftWriteResult = {
+  providerDraftId: string;
+  providerMessageId: string;
+  providerThreadId: string;
+};
+
+export type BeginGmailDraftWriteResult =
+  | { outcome: "claimed"; operationId: string }
+  | { outcome: "pending"; operationId: string }
+  | {
+      outcome: "complete";
+      operationId: string;
+      result: GmailDraftWriteResult;
+    };
+
+export class GmailDraftWriteConflictError extends Error {
+  constructor() {
+    super("The idempotency key was already used for a different Gmail draft write.");
+    this.name = "GmailDraftWriteConflictError";
+  }
+}
+
+export async function beginGmailDraftWrite(
+  input: {
+    userId: string;
+    accountId: string;
+    operation: GmailDraftWriteOperation;
+    idempotencyKey: string;
+    requestFingerprint: string;
+  },
+  database: Database = getDatabase(),
+): Promise<BeginGmailDraftWriteResult> {
+  const [inserted] = await database
+    .insert(gmailDraftWriteOperations)
+    .values({
+      ...input,
+      status: "pending",
+    })
+    .onConflictDoNothing({
+      target: [
+        gmailDraftWriteOperations.userId,
+        gmailDraftWriteOperations.idempotencyKey,
+      ],
+    })
+    .returning({ id: gmailDraftWriteOperations.id });
+  if (inserted) return { outcome: "claimed", operationId: inserted.id };
+
+  const [existing] = await database
+    .select({
+      id: gmailDraftWriteOperations.id,
+      accountId: gmailDraftWriteOperations.accountId,
+      operation: gmailDraftWriteOperations.operation,
+      status: gmailDraftWriteOperations.status,
+      requestFingerprint: gmailDraftWriteOperations.requestFingerprint,
+      providerDraftId: gmailDraftWriteOperations.providerDraftId,
+      providerMessageId: gmailDraftWriteOperations.providerMessageId,
+      providerThreadId: gmailDraftWriteOperations.providerThreadId,
+    })
+    .from(gmailDraftWriteOperations)
+    .where(
+      and(
+        eq(gmailDraftWriteOperations.userId, input.userId),
+        eq(gmailDraftWriteOperations.idempotencyKey, input.idempotencyKey),
+      ),
+    )
+    .limit(1);
+  if (!existing) {
+    throw new Error("The Gmail draft write idempotency record could not be read.");
+  }
+  if (
+    existing.accountId !== input.accountId ||
+    existing.operation !== input.operation ||
+    existing.requestFingerprint !== input.requestFingerprint
+  ) {
+    throw new GmailDraftWriteConflictError();
+  }
+  if (existing.status === "pending") {
+    return { outcome: "pending", operationId: existing.id };
+  }
+  if (
+    !existing.providerDraftId ||
+    !existing.providerMessageId ||
+    !existing.providerThreadId
+  ) {
+    throw new Error("The completed Gmail draft write has no provider result.");
+  }
+  return {
+    outcome: "complete",
+    operationId: existing.id,
+    result: {
+      providerDraftId: existing.providerDraftId,
+      providerMessageId: existing.providerMessageId,
+      providerThreadId: existing.providerThreadId,
+    },
+  };
+}
+
+export async function completeGmailDraftWrite(
+  input: {
+    operationId: string;
+    userId: string;
+    result: GmailDraftWriteResult;
+  },
+  database: Database = getDatabase(),
+): Promise<void> {
+  const [completed] = await database
+    .update(gmailDraftWriteOperations)
+    .set({
+      status: "complete",
+      providerDraftId: input.result.providerDraftId,
+      providerMessageId: input.result.providerMessageId,
+      providerThreadId: input.result.providerThreadId,
+      completedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(gmailDraftWriteOperations.id, input.operationId),
+        eq(gmailDraftWriteOperations.userId, input.userId),
+        eq(gmailDraftWriteOperations.status, "pending"),
+      ),
+    )
+    .returning({ id: gmailDraftWriteOperations.id });
+  if (completed) return;
+
+  const [existing] = await database
+    .select({
+      status: gmailDraftWriteOperations.status,
+      providerDraftId: gmailDraftWriteOperations.providerDraftId,
+      providerMessageId: gmailDraftWriteOperations.providerMessageId,
+      providerThreadId: gmailDraftWriteOperations.providerThreadId,
+    })
+    .from(gmailDraftWriteOperations)
+    .where(
+      and(
+        eq(gmailDraftWriteOperations.id, input.operationId),
+        eq(gmailDraftWriteOperations.userId, input.userId),
+      ),
+    )
+    .limit(1);
+  if (
+    existing?.status === "complete" &&
+    existing.providerDraftId === input.result.providerDraftId &&
+    existing.providerMessageId === input.result.providerMessageId &&
+    existing.providerThreadId === input.result.providerThreadId
+  ) {
+    return;
+  }
+  throw new Error("The Gmail draft write result could not be persisted.");
+}
+
+export async function abandonPendingGmailDraftWrite(
+  input: { operationId: string; userId: string },
+  database: Database = getDatabase(),
+): Promise<void> {
+  await database
+    .delete(gmailDraftWriteOperations)
+    .where(
+      and(
+        eq(gmailDraftWriteOperations.id, input.operationId),
+        eq(gmailDraftWriteOperations.userId, input.userId),
+        eq(gmailDraftWriteOperations.status, "pending"),
+      ),
+    );
+}

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -12,6 +12,7 @@ export {
   encryptGoogleCredential,
   type GoogleCredential,
 } from "./credentials";
+export * from "./gmail-draft-writes";
 export * from "./mailbox-actions";
 export * from "./gmail-watch";
 export * from "./repositories";

--- a/packages/database/src/replica.ts
+++ b/packages/database/src/replica.ts
@@ -546,7 +546,12 @@ export async function ingestGmailPushEvent(
 }
 
 export async function enqueueGmailHistoryCatchup(
-  input: { userId: string; accountId: string; reason: "manual" | "provider_write" },
+  input: {
+    userId: string;
+    accountId: string;
+    reason: "manual" | "provider_write";
+    sourceId?: string;
+  },
   database: Database = getDatabase(),
 ) {
   return enqueueWorkflowStep(
@@ -555,7 +560,7 @@ export async function enqueueGmailHistoryCatchup(
       accountId: input.accountId,
       stepType: "gmail.history.catchup",
       payload: { reason: input.reason },
-      idempotencyKey: `gmail-history-${input.reason}:${input.accountId}:${uuidv4()}`,
+      idempotencyKey: `gmail-history-${input.reason}:${input.accountId}:${input.sourceId ?? uuidv4()}`,
     },
     database,
   );

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -845,6 +845,55 @@ export const gmailDrafts = pgTable(
   ],
 );
 
+export const gmailDraftWriteOperations = pgTable(
+  "gmail_draft_write_operations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => profiles.id, { onDelete: "cascade" }),
+    accountId: uuid("account_id")
+      .notNull()
+      .references(() => connectedAccounts.id, { onDelete: "cascade" }),
+    operation: text("operation").$type<"create" | "update">().notNull(),
+    status: text("status").$type<"pending" | "complete">().notNull(),
+    idempotencyKey: uuid("idempotency_key").notNull(),
+    requestFingerprint: text("request_fingerprint").notNull(),
+    providerDraftId: text("provider_draft_id"),
+    providerMessageId: text("provider_message_id"),
+    providerThreadId: text("provider_thread_id"),
+    completedAt: timestampWithTimezone("completed_at"),
+    createdAt: timestampWithTimezone("created_at").notNull().defaultNow(),
+    updatedAt: timestampWithTimezone("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    uniqueIndex("gmail_draft_write_operations_user_key_idx").on(
+      table.userId,
+      table.idempotencyKey,
+    ),
+    index("gmail_draft_write_operations_account_status_idx").on(
+      table.accountId,
+      table.status,
+      table.createdAt,
+    ),
+    check(
+      "gmail_draft_write_operations_operation_check",
+      sql`${table.operation} in ('create', 'update')`,
+    ),
+    check(
+      "gmail_draft_write_operations_status_check",
+      sql`${table.status} in ('pending', 'complete')`,
+    ),
+    check(
+      "gmail_draft_write_operations_result_check",
+      sql`(${table.status} = 'pending' and ${table.providerDraftId} is null and ${table.providerMessageId} is null and ${table.providerThreadId} is null and ${table.completedAt} is null) or (${table.status} = 'complete' and ${table.providerDraftId} is not null and ${table.providerMessageId} is not null and ${table.providerThreadId} is not null and ${table.completedAt} is not null)`,
+    ),
+  ],
+);
+
 export const mailSyncRuns = pgTable(
   "mail_sync_runs",
   {

--- a/packages/gmail/src/client.test.ts
+++ b/packages/gmail/src/client.test.ts
@@ -8,6 +8,7 @@ import {
   GMAIL_MESSAGE_LIST_MAX_RESULTS,
   getGmailMessage,
   isGoogleReauthenticationRequired,
+  listGmailDrafts,
   listGmailMessages,
 } from "./client";
 
@@ -86,4 +87,21 @@ test("a transient Google provider failure remains retryable", () => {
   );
 
   assert.equal(isGoogleReauthenticationRequired(error), false);
+});
+
+test("Gmail draft listing forwards an exact provider search query", async () => {
+  requests.length = 0;
+  await listGmailDrafts("access-token", {
+    maxResults: 10,
+    query: "rfc822msgid:invook-compose@example.invalid",
+  });
+
+  const request = requests[0];
+  assert.ok(request);
+  const url = new URL(request.url ?? "", request.baseURL);
+  assert.equal(url.pathname, "/users/me/drafts");
+  assert.equal(
+    url.searchParams.get("q"),
+    "rfc822msgid:invook-compose@example.invalid",
+  );
 });

--- a/packages/gmail/src/client.ts
+++ b/packages/gmail/src/client.ts
@@ -427,10 +427,11 @@ export function untrashGmailMessage(
 
 export function listGmailDrafts(
   accessToken: string,
-  options: { maxResults: number; pageToken?: string },
+  options: { maxResults: number; pageToken?: string; query?: string },
 ): Promise<GmailDraftPage> {
   const search = new URLSearchParams({ maxResults: String(options.maxResults) });
   if (options.pageToken) search.set("pageToken", options.pageToken);
+  if (options.query) search.set("q", options.query);
   return gmailRequest<GmailDraftPage>(
     accessToken,
     `/users/me/drafts?${search.toString()}`,

--- a/packages/gmail/src/draft.test.ts
+++ b/packages/gmail/src/draft.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { composePlainTextGmailMessage } from "./draft";
+
+test("new Gmail messages contain the requested recipients, stable message ID, and CRLF body", () => {
+  const raw = composePlainTextGmailMessage({
+    accountEmail: "owner@example.com",
+    recipients: ["first@example.com", "second@example.com"],
+    subject: "Quarterly update",
+    body: "First line\nSecond line",
+    messageId: "invook-compose-operation@example.invalid",
+  });
+
+  assert.ok(raw);
+  assert.equal(
+    raw.toString("utf8"),
+    [
+      "From: owner@example.com",
+      "To: first@example.com, second@example.com",
+      "Subject: Quarterly update",
+      "Message-ID: <invook-compose-operation@example.invalid>",
+      "MIME-Version: 1.0",
+      "Content-Type: text/plain; charset=UTF-8",
+      "Content-Transfer-Encoding: 8bit",
+      "",
+      "First line",
+      "Second line",
+    ].join("\r\n"),
+  );
+});
+
+test("new Gmail message headers cannot be injected and unicode subjects are encoded", () => {
+  const raw = composePlainTextGmailMessage({
+    accountEmail: "owner@example.com\r\nBcc: hidden@example.com",
+    recipients: ["person@example.com\r\nCc: hidden@example.com"],
+    subject: "Résumé\r\nBcc: hidden@example.com",
+    body: "Body",
+    messageId: "operation@example.invalid\r\nX-Injected: true",
+  });
+
+  assert.ok(raw);
+  const message = raw.toString("utf8");
+  assert.match(message, /Subject: =\?UTF-8\?B\?/);
+  assert.doesNotMatch(message, /\r\nBcc:/);
+  assert.doesNotMatch(message, /\r\nCc:/);
+  assert.doesNotMatch(message, /\r\nX-Injected:/);
+});

--- a/packages/gmail/src/draft.ts
+++ b/packages/gmail/src/draft.ts
@@ -24,6 +24,42 @@ function normalizeBody(value: string): string {
   return value.replace(/\r\n|\r|\n/g, "\r\n");
 }
 
+function subjectHeaderValue(value: string): string {
+  const subject = safeHeaderValue(value);
+  return /^[\u0020-\u007e]*$/.test(subject)
+    ? subject
+    : `=?UTF-8?B?${Buffer.from(subject, "utf8").toString("base64")}?=`;
+}
+
+export function composePlainTextGmailMessage(input: {
+  accountEmail: string;
+  recipients: string[];
+  subject: string;
+  body: string;
+  messageId: string;
+}): Buffer | null {
+  const sender = safeHeaderValue(input.accountEmail);
+  const recipients = input.recipients
+    .map((recipient) => safeHeaderValue(recipient))
+    .filter(Boolean);
+  const rawMessageId = safeHeaderValue(input.messageId).replace(/^<|>$/g, "");
+  if (!sender || recipients.length === 0 || !rawMessageId) return null;
+
+  const headers = [
+    `From: ${sender}`,
+    `To: ${recipients.join(", ")}`,
+    `Subject: ${subjectHeaderValue(input.subject)}`,
+    `Message-ID: <${rawMessageId}>`,
+    "MIME-Version: 1.0",
+    "Content-Type: text/plain; charset=UTF-8",
+    "Content-Transfer-Encoding: 8bit",
+  ];
+  return Buffer.from(
+    `${headers.join("\r\n")}\r\n\r\n${normalizeBody(input.body)}`,
+    "utf8",
+  );
+}
+
 export function composePlainTextGmailReply(input: {
   accountEmail: string;
   subject: string;

--- a/packages/gmail/src/index.ts
+++ b/packages/gmail/src/index.ts
@@ -40,7 +40,10 @@ export {
   type GmailRawMessage,
   type GmailWatchResponse,
 } from "./client";
-export { composePlainTextGmailReply } from "./draft";
+export {
+  composePlainTextGmailMessage,
+  composePlainTextGmailReply,
+} from "./draft";
 export {
   extractEmailAddress,
   isMemoryEligible,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -207,6 +207,12 @@ importers:
 
   packages/contracts:
     devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      tsx:
+        specifier: ^4.20.0
+        version: 4.23.11
       typescript:
         specifier: ^5.9.0
         version: 5.9.3


### PR DESCRIPTION
## Summary

- add shared validation contracts and safe plain-text MIME composition for new Gmail drafts
- create and update Gmail Draft resources through authenticated Fastify routes with a durable idempotency ledger and stable stored-cursor history catch-up
- replace the placeholder Compose surface with controlled recipient, subject, and body fields plus explicit saving, saved, validation, and error states
- keep sending unavailable and avoid optimistic local Gmail draft state

## Verification

- make verify
- PostgreSQL migration 0018 applied successfully
- database idempotency integration test passed against local PostgreSQL
- docker compose -f docker/compose.yml config --quiet

## Live Gmail status

Not verified against Gmail yet. The local environment has zero profiles, zero connected accounts, and zero ready replicas, so a clean signup was not available. Real provider draft creation and later replica convergence remain the only unverified integration steps.