### PR TITLE
Add guarded clean-local-signup reset workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: dev down verify
+.PHONY: dev down reset-local verify
 
 dev:
 	./docker/dev-local.sh
 
 down:
 	docker compose -f docker/compose.yml down
+
+reset-local:
+	./docker/reset-local.sh --confirm invook-local-data
 
 verify:
 	pnpm typecheck

--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ Stop it with:
 make down
 ```
 
+To clear local signup, mailbox, workflow, queue and object-storage data without deleting schemas, migrations, buckets or Docker volumes, use:
+
+```bash
+make reset-local
+```
+
+The command stops application services, refuses non-local or unknown Docker configurations, restarts the normal stack and prints zero-state evidence. See [Reset local signup and mailbox data](./docs/local-development-reset.md) for its exact scope and safeguards.
+
 ## Run application processes outside Docker
 
 Use the same root `.env.local`:

--- a/docker/reset-local-config.test.ts
+++ b/docker/reset-local-config.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { validateLocalResetConfiguration } from "./reset-local-config.ts";
+
+const localEnvironment = {
+  databaseUrl: "postgresql://invook:invook@127.0.0.1:54322/invook",
+  redisUrl: "redis://127.0.0.1:63790",
+  s3Bucket: "invook-mail",
+  s3Endpoint: "http://localhost:9000",
+};
+
+function createComposeConfig() {
+  const databaseUrl = "postgresql://invook:invook@db:5432/invook";
+  const port = (target: number, published: string, hostIp?: string) => ({
+    mode: "ingress",
+    ...(hostIp ? { host_ip: hostIp } : {}),
+    protocol: "tcp",
+    published,
+    target,
+  });
+  return {
+    name: "invook",
+    services: {
+      api: {
+        environment: { DATABASE_URL: databaseUrl },
+        ports: [port(4000, "4000")],
+      },
+      db: {
+        environment: {
+          POSTGRES_DB: "invook",
+          POSTGRES_PASSWORD: "invook",
+          POSTGRES_USER: "invook",
+        },
+        ports: [port(5432, "54322")],
+        volumes: [
+          {
+            source: "invook-postgres",
+            target: "/var/lib/postgresql/data",
+            type: "volume",
+          },
+        ],
+      },
+      migrate: { environment: { DATABASE_URL: databaseUrl } },
+      minio: {
+        ports: [
+          port(9000, "9000", "127.0.0.1"),
+          port(9001, "9001", "127.0.0.1"),
+        ],
+        volumes: [
+          { source: "invook-minio", target: "/data", type: "volume" },
+        ],
+      },
+      "minio-init": { environment: { S3_BUCKET: "invook-mail" } },
+      redis: {
+        ports: [port(6379, "63790")],
+        volumes: [
+          { source: "invook-redis", target: "/data", type: "volume" },
+        ],
+      },
+      web: { ports: [port(3000, "3000")] },
+      worker: {
+        environment: {
+          DATABASE_URL: databaseUrl,
+          REDIS_URL: "redis://redis:6379",
+          S3_BUCKET: "invook-mail",
+          S3_ENDPOINT: "http://minio:9000",
+        },
+      },
+    },
+    volumes: {
+      "invook-minio": { name: "invook_invook-minio" },
+      "invook-postgres": { name: "invook_invook-postgres" },
+      "invook-redis": { name: "invook_invook-redis" },
+    },
+  };
+}
+
+describe("validateLocalResetConfiguration", () => {
+  it("accepts the known local Docker configuration", () => {
+    assert.doesNotThrow(() =>
+      validateLocalResetConfiguration(createComposeConfig(), localEnvironment),
+    );
+  });
+
+  it("rejects a remote PostgreSQL target", () => {
+    assert.throws(
+      () =>
+        validateLocalResetConfiguration(createComposeConfig(), {
+          ...localEnvironment,
+          databaseUrl: "postgresql://invook:invook@db.example.com:5432/invook",
+        }),
+      /known Invook PostgreSQL service/,
+    );
+  });
+
+  it("rejects a nonzero Redis database", () => {
+    assert.throws(
+      () =>
+        validateLocalResetConfiguration(createComposeConfig(), {
+          ...localEnvironment,
+          redisUrl: "redis://127.0.0.1:63790/1",
+        }),
+      /database 0/,
+    );
+  });
+
+  it("rejects another Compose project", () => {
+    const composeConfig = createComposeConfig();
+    composeConfig.name = "invook-production";
+    assert.throws(
+      () => validateLocalResetConfiguration(composeConfig, localEnvironment),
+      /project name must be invook/,
+    );
+  });
+
+  it("rejects an unknown service", () => {
+    const composeConfig = createComposeConfig();
+    Object.assign(composeConfig.services, { analytics: {} });
+    assert.throws(
+      () => validateLocalResetConfiguration(composeConfig, localEnvironment),
+      /services do not match/,
+    );
+  });
+
+  it("rejects a different PostgreSQL volume", () => {
+    const composeConfig = createComposeConfig();
+    composeConfig.services.db.volumes[0].source = "shared-postgres";
+    assert.throws(
+      () => validateLocalResetConfiguration(composeConfig, localEnvironment),
+      /known local named volume/,
+    );
+  });
+
+  it("rejects a worker pointed at another Redis service", () => {
+    const composeConfig = createComposeConfig();
+    composeConfig.services.worker.environment.REDIS_URL =
+      "redis://shared-redis:6379";
+    assert.throws(
+      () => validateLocalResetConfiguration(composeConfig, localEnvironment),
+      /known local REDIS_URL/,
+    );
+  });
+
+  it("rejects another object-storage bucket", () => {
+    assert.throws(
+      () =>
+        validateLocalResetConfiguration(createComposeConfig(), {
+          ...localEnvironment,
+          s3Bucket: "shared-mail",
+        }),
+      /known local invook-mail bucket/,
+    );
+  });
+});

--- a/docker/reset-local-config.ts
+++ b/docker/reset-local-config.ts
@@ -1,0 +1,313 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+interface LocalResetEnvironment {
+  databaseUrl: string | undefined;
+  redisUrl: string | undefined;
+  s3Bucket: string | undefined;
+  s3Endpoint: string | undefined;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+const EXPECTED_SERVICE_NAMES = [
+  "api",
+  "db",
+  "migrate",
+  "minio",
+  "minio-init",
+  "redis",
+  "web",
+  "worker",
+];
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, description: string): JsonRecord {
+  if (!isJsonRecord(value)) {
+    throw new Error(`${description} is missing or invalid.`);
+  }
+  return value;
+}
+
+function requireService(services: JsonRecord, serviceName: string): JsonRecord {
+  return requireRecord(services[serviceName], `Compose service ${serviceName}`);
+}
+
+function requireEnvironment(service: JsonRecord, serviceName: string): JsonRecord {
+  return requireRecord(
+    service.environment,
+    `Compose service ${serviceName} environment`,
+  );
+}
+
+function assertEnvironmentValue(
+  service: JsonRecord,
+  serviceName: string,
+  variableName: string,
+  expectedValue: string,
+): void {
+  const environment = requireEnvironment(service, serviceName);
+  if (environment[variableName] !== expectedValue) {
+    throw new Error(
+      `Compose service ${serviceName} must use the known local ${variableName} value.`,
+    );
+  }
+}
+
+function assertNamedVolume(
+  service: JsonRecord,
+  serviceName: string,
+  expectedSource: string,
+  expectedTarget: string,
+): void {
+  const volumes = service.volumes;
+  if (!Array.isArray(volumes) || volumes.length !== 1) {
+    throw new Error(
+      `Compose service ${serviceName} must have exactly one known local volume.`,
+    );
+  }
+  const volume = requireRecord(volumes[0], `Compose service ${serviceName} volume`);
+  if (
+    volume.type !== "volume" ||
+    volume.source !== expectedSource ||
+    volume.target !== expectedTarget
+  ) {
+    throw new Error(
+      `Compose service ${serviceName} is not using its known local named volume.`,
+    );
+  }
+}
+
+interface ExpectedPort {
+  hostIp?: string;
+  published: string;
+  target: number;
+}
+
+function assertPorts(
+  service: JsonRecord,
+  serviceName: string,
+  expectedPorts: ExpectedPort[],
+): void {
+  const ports = service.ports;
+  if (!Array.isArray(ports) || ports.length !== expectedPorts.length) {
+    throw new Error(
+      `Compose service ${serviceName} does not expose the known local ports.`,
+    );
+  }
+  for (const expectedPort of expectedPorts) {
+    const hasExpectedPort = ports.some((value: unknown) => {
+      const port = requireRecord(value, `Compose service ${serviceName} port`);
+      return (
+        port.target === expectedPort.target &&
+        port.published === expectedPort.published &&
+        port.protocol === "tcp" &&
+        port.mode === "ingress" &&
+        port.host_ip === expectedPort.hostIp
+      );
+    });
+    if (!hasExpectedPort) {
+      throw new Error(
+        `Compose service ${serviceName} does not expose the known local ports.`,
+      );
+    }
+  }
+}
+
+function parseUrl(value: string | undefined, variableName: string): URL {
+  if (!value) {
+    throw new Error(`${variableName} must be configured in .env.local.`);
+  }
+  try {
+    return new URL(value);
+  } catch {
+    throw new Error(`${variableName} in .env.local is not a valid URL.`);
+  }
+}
+
+function assertLocalDatabaseUrl(value: string | undefined): void {
+  const databaseUrl = parseUrl(value, "DATABASE_URL");
+  const isLocalHost =
+    databaseUrl.hostname === "127.0.0.1" ||
+    databaseUrl.hostname === "localhost";
+  if (
+    databaseUrl.protocol !== "postgresql:" ||
+    !isLocalHost ||
+    databaseUrl.port !== "54322" ||
+    databaseUrl.pathname !== "/invook" ||
+    databaseUrl.username !== "invook" ||
+    databaseUrl.password !== "invook" ||
+    databaseUrl.search !== "" ||
+    databaseUrl.hash !== ""
+  ) {
+    throw new Error(
+      "DATABASE_URL must target the known Invook PostgreSQL service on localhost:54322.",
+    );
+  }
+}
+
+function assertLocalRedisUrl(value: string | undefined): void {
+  const redisUrl = parseUrl(value, "REDIS_URL");
+  const isLocalHost =
+    redisUrl.hostname === "127.0.0.1" || redisUrl.hostname === "localhost";
+  const isDatabaseZero =
+    redisUrl.pathname === "" ||
+    redisUrl.pathname === "/" ||
+    redisUrl.pathname === "/0";
+  if (
+    redisUrl.protocol !== "redis:" ||
+    !isLocalHost ||
+    redisUrl.port !== "63790" ||
+    !isDatabaseZero ||
+    redisUrl.username !== "" ||
+    redisUrl.password !== "" ||
+    redisUrl.search !== "" ||
+    redisUrl.hash !== ""
+  ) {
+    throw new Error(
+      "REDIS_URL must target database 0 of the known Invook Redis service on localhost:63790.",
+    );
+  }
+}
+
+function assertLocalObjectStorage(environment: LocalResetEnvironment): void {
+  if (
+    environment.s3Endpoint !== undefined &&
+    environment.s3Endpoint !== "" &&
+    environment.s3Endpoint !== "http://localhost:9000" &&
+    environment.s3Endpoint !== "http://127.0.0.1:9000"
+  ) {
+    throw new Error(
+      "S3_ENDPOINT must target the known Invook MinIO service on localhost:9000.",
+    );
+  }
+  if (
+    environment.s3Bucket !== undefined &&
+    environment.s3Bucket !== "" &&
+    environment.s3Bucket !== "invook-mail"
+  ) {
+    throw new Error("S3_BUCKET must be the known local invook-mail bucket.");
+  }
+}
+
+function assertTopLevelVolumes(composeConfig: JsonRecord): void {
+  const volumes = requireRecord(composeConfig.volumes, "Compose volumes");
+  const expectedVolumeNames: Record<string, string> = {
+    "invook-minio": "invook_invook-minio",
+    "invook-postgres": "invook_invook-postgres",
+    "invook-redis": "invook_invook-redis",
+  };
+  if (
+    Object.keys(volumes).sort().join(",") !==
+    Object.keys(expectedVolumeNames).sort().join(",")
+  ) {
+    throw new Error("Compose must define only the known Invook local volumes.");
+  }
+  for (const [volumeName, expectedResolvedName] of Object.entries(
+    expectedVolumeNames,
+  )) {
+    const volume = requireRecord(volumes[volumeName], `Compose volume ${volumeName}`);
+    if (volume.name !== expectedResolvedName) {
+      throw new Error(
+        `Compose volume ${volumeName} does not resolve to the known local volume.`,
+      );
+    }
+  }
+}
+
+export function validateLocalResetConfiguration(
+  composeValue: unknown,
+  environment: LocalResetEnvironment,
+): void {
+  assertLocalDatabaseUrl(environment.databaseUrl);
+  assertLocalRedisUrl(environment.redisUrl);
+  assertLocalObjectStorage(environment);
+
+  const composeConfig = requireRecord(composeValue, "Compose configuration");
+  if (composeConfig.name !== "invook") {
+    throw new Error("Compose project name must be invook.");
+  }
+  const services = requireRecord(composeConfig.services, "Compose services");
+  if (
+    Object.keys(services).sort().join(",") !==
+    [...EXPECTED_SERVICE_NAMES].sort().join(",")
+  ) {
+    throw new Error("Compose services do not match the known Invook local stack.");
+  }
+
+  const api = requireService(services, "api");
+  const database = requireService(services, "db");
+  const migrate = requireService(services, "migrate");
+  const minio = requireService(services, "minio");
+  const minioInit = requireService(services, "minio-init");
+  const redis = requireService(services, "redis");
+  const web = requireService(services, "web");
+  const worker = requireService(services, "worker");
+
+  assertEnvironmentValue(database, "db", "POSTGRES_USER", "invook");
+  assertEnvironmentValue(database, "db", "POSTGRES_PASSWORD", "invook");
+  assertEnvironmentValue(database, "db", "POSTGRES_DB", "invook");
+  assertEnvironmentValue(
+    api,
+    "api",
+    "DATABASE_URL",
+    "postgresql://invook:invook@db:5432/invook",
+  );
+  assertEnvironmentValue(
+    migrate,
+    "migrate",
+    "DATABASE_URL",
+    "postgresql://invook:invook@db:5432/invook",
+  );
+  assertEnvironmentValue(
+    worker,
+    "worker",
+    "DATABASE_URL",
+    "postgresql://invook:invook@db:5432/invook",
+  );
+  assertEnvironmentValue(worker, "worker", "REDIS_URL", "redis://redis:6379");
+  assertEnvironmentValue(worker, "worker", "S3_ENDPOINT", "http://minio:9000");
+  assertEnvironmentValue(worker, "worker", "S3_BUCKET", "invook-mail");
+  assertEnvironmentValue(minioInit, "minio-init", "S3_BUCKET", "invook-mail");
+
+  assertNamedVolume(database, "db", "invook-postgres", "/var/lib/postgresql/data");
+  assertNamedVolume(redis, "redis", "invook-redis", "/data");
+  assertNamedVolume(minio, "minio", "invook-minio", "/data");
+
+  assertPorts(database, "db", [{ published: "54322", target: 5432 }]);
+  assertPorts(redis, "redis", [{ published: "63790", target: 6379 }]);
+  assertPorts(minio, "minio", [
+    { hostIp: "127.0.0.1", published: "9000", target: 9000 },
+    { hostIp: "127.0.0.1", published: "9001", target: 9001 },
+  ]);
+  assertPorts(api, "api", [{ published: "4000", target: 4000 }]);
+  assertPorts(web, "web", [{ published: "3000", target: 3000 }]);
+
+  assertTopLevelVolumes(composeConfig);
+}
+
+function runCli(): void {
+  try {
+    const composeConfig: unknown = JSON.parse(readFileSync(0, "utf8"));
+    validateLocalResetConfiguration(composeConfig, {
+      databaseUrl: process.env.DATABASE_URL,
+      redisUrl: process.env.REDIS_URL,
+      s3Bucket: process.env.S3_BUCKET,
+      s3Endpoint: process.env.S3_ENDPOINT,
+    });
+    console.info("Local reset safety checks passed.");
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Unknown validation error.";
+    console.error(`Refusing local reset: ${message}`);
+    process.exitCode = 1;
+  }
+}
+
+const entryPath = process.argv[1];
+if (entryPath && import.meta.url === pathToFileURL(resolve(entryPath)).href) {
+  runCli();
+}

--- a/docker/reset-local.sh
+++ b/docker/reset-local.sh
@@ -120,9 +120,6 @@ compose run --rm --no-deps --entrypoint /bin/sh minio-init -c '
   }
 '
 
-echo "Data stores cleared; restarting the normal local stack."
-compose up -d --build --wait
-
 compose exec -T db sh -c "$psql_command" <<'SQL'
 DO $$
 DECLARE
@@ -202,4 +199,6 @@ echo "drizzle_migrations_preserved=$migration_count_after"
 echo "redis_keys_after_flush=$redis_keys_after_flush"
 echo "$queue_evidence"
 echo "mailbox_objects=0"
+echo "Data stores cleared and verified; restarting the normal local stack."
+compose up -d --build --wait
 echo "Local reset complete. Open http://localhost:3000 to start a new Google signup."

--- a/docker/reset-local.sh
+++ b/docker/reset-local.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env sh
+set -eu
+
+fail() {
+  echo "Local reset failed: $*" >&2
+  exit 1
+}
+
+if [ "$#" -ne 2 ] || [ "$1" != "--confirm" ] || [ "$2" != "invook-local-data" ]; then
+  echo "Usage: $0 --confirm invook-local-data" >&2
+  exit 2
+fi
+
+project_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$project_root"
+
+[ -f .env.local ] || fail "create .env.local from .env.example first."
+
+set -a
+. ./.env.local
+set +a
+
+export DATABASE_URL_DOCKER="postgresql://invook:invook@db:5432/invook"
+export REDIS_URL_DOCKER="redis://redis:6379"
+
+compose_file="docker/compose.yml"
+
+compose() {
+  docker compose -f "$compose_file" "$@"
+}
+
+compose config --format json | pnpm exec tsx docker/reset-local-config.ts
+
+echo "Reset scope: PostgreSQL product rows, Redis database 0, and objects in MinIO bucket invook-mail."
+echo "Preserved: schemas, Drizzle migrations, the MinIO bucket, Docker volumes, .env.local, credentials, and source files."
+
+if ! compose stop web api worker; then
+  echo "Compose reported a stop error; verifying that all application services stopped." >&2
+fi
+
+for service_name in web api worker; do
+  container_id=$(compose ps -a -q "$service_name")
+  if [ -n "$container_id" ] && [ "$(docker inspect "$container_id" --format '{{.State.Running}}')" != "false" ]; then
+    fail "application service $service_name is still running."
+  fi
+done
+
+echo "Application services stopped."
+compose up -d --wait db redis minio
+
+for service_name in db redis minio; do
+  container_id=$(compose ps -q "$service_name")
+  [ -n "$container_id" ] || fail "local $service_name container is not running."
+  project_label=$(docker inspect "$container_id" --format '{{index .Config.Labels "com.docker.compose.project"}}')
+  service_label=$(docker inspect "$container_id" --format '{{index .Config.Labels "com.docker.compose.service"}}')
+  [ "$project_label" = "invook" ] || fail "$service_name container is not in the invook project."
+  [ "$service_label" = "$service_name" ] || fail "$service_name container label does not match."
+done
+
+psql_command='psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
+
+migration_count_before=$(compose exec -T db sh -c "$psql_command -Atc 'SELECT count(*) FROM drizzle.__drizzle_migrations'")
+case "$migration_count_before" in
+  ''|*[!0-9]*) fail "could not read the Drizzle migration history." ;;
+esac
+[ "$migration_count_before" -gt 0 ] || fail "the Drizzle migration history is empty."
+
+unexpected_schema_tables=$(compose exec -T db sh -c "$psql_command -Atc \"SELECT count(*) FROM pg_tables WHERE schemaname NOT IN ('public', 'drizzle', 'information_schema') AND schemaname NOT LIKE 'pg_%'\"")
+[ "$unexpected_schema_tables" -eq 0 ] || fail "application tables exist outside the known public schema."
+
+missing_required_tables=$(compose exec -T db sh -c "$psql_command -At" <<'SQL'
+SELECT count(*)
+FROM (
+  VALUES
+    ('profiles'),
+    ('connected_accounts'),
+    ('messages'),
+    ('message_embeddings'),
+    ('drafts'),
+    ('memory_entries'),
+    ('workflow_steps'),
+    ('queue_outbox')
+) AS required(table_name)
+WHERE to_regclass('public.' || quote_ident(required.table_name)) IS NULL;
+SQL
+)
+[ "$missing_required_tables" -eq 0 ] || fail "the PostgreSQL schema does not match the known Invook product schema."
+
+compose exec -T db sh -c "$psql_command" <<'SQL'
+BEGIN;
+SELECT format('TRUNCATE TABLE %I.%I RESTART IDENTITY CASCADE;', schemaname, tablename)
+FROM pg_tables
+WHERE schemaname = 'public'
+  AND tablename <> '__drizzle_migrations'
+ORDER BY tablename
+\gexec
+COMMIT;
+SQL
+
+compose exec -T redis redis-cli -n 0 FLUSHDB >/dev/null
+redis_keys_after_flush=$(compose exec -T redis redis-cli -n 0 DBSIZE)
+[ "$redis_keys_after_flush" -eq 0 ] || fail "Redis database 0 was not emptied."
+
+compose run --rm --no-deps --entrypoint /bin/sh minio-init -c '
+  set -eu
+  [ "$S3_BUCKET" = "invook-mail" ]
+  mc alias set invook http://minio:9000 "$S3_ACCESS_KEY_ID" "$S3_SECRET_ACCESS_KEY" >/dev/null
+  version_state=$(mc version info "invook/$S3_BUCKET")
+  case "$version_state" in
+    *" is un-versioned") ;;
+    *) echo "Local reset failed: MinIO bucket must be the known unversioned local bucket." >&2; exit 1 ;;
+  esac
+  mc rm --recursive --force --dangerous "invook/$S3_BUCKET" >/dev/null
+  mc stat "invook/$S3_BUCKET" >/dev/null
+  listing_file=/tmp/invook-reset-object-listing
+  mc ls --recursive --json "invook/$S3_BUCKET" >"$listing_file"
+  [ ! -s "$listing_file" ] || {
+    echo "Local reset failed: MinIO bucket still contains objects." >&2
+    exit 1
+  }
+'
+
+echo "Data stores cleared; restarting the normal local stack."
+compose up -d --build --wait
+
+compose exec -T db sh -c "$psql_command" <<'SQL'
+DO $$
+DECLARE
+  application_table record;
+  row_count bigint;
+BEGIN
+  FOR application_table IN
+    SELECT schemaname, tablename
+    FROM pg_tables
+    WHERE schemaname = 'public'
+      AND tablename <> '__drizzle_migrations'
+  LOOP
+    EXECUTE format(
+      'SELECT count(*) FROM %I.%I',
+      application_table.schemaname,
+      application_table.tablename
+    ) INTO row_count;
+    IF row_count <> 0 THEN
+      RAISE EXCEPTION 'Product table %.% is not empty',
+        application_table.schemaname,
+        application_table.tablename;
+    END IF;
+  END LOOP;
+END
+$$;
+SQL
+
+migration_count_after=$(compose exec -T db sh -c "$psql_command -Atc 'SELECT count(*) FROM drizzle.__drizzle_migrations'")
+[ "$migration_count_after" = "$migration_count_before" ] || fail "Drizzle migration history changed during reset."
+
+database_evidence=$(compose exec -T db sh -c "$psql_command -At" <<'SQL'
+SELECT 'profiles=' || count(*) FROM profiles
+UNION ALL SELECT 'connected_accounts=' || count(*) FROM connected_accounts
+UNION ALL SELECT 'messages=' || count(*) FROM messages
+UNION ALL SELECT 'message_embeddings=' || count(*) FROM message_embeddings
+UNION ALL SELECT 'drafts=' || count(*) FROM drafts
+UNION ALL SELECT 'gmail_drafts=' || count(*) FROM gmail_drafts
+UNION ALL SELECT 'memory_entries=' || count(*) FROM memory_entries
+UNION ALL SELECT 'workflow_steps=' || count(*) FROM workflow_steps
+UNION ALL SELECT 'queue_outbox=' || count(*) FROM queue_outbox;
+SQL
+)
+
+queue_evidence=$(compose exec -T redis sh -c '
+  set -eu
+  total=0
+  for queue_name in gmail-pages gmail-messages gmail-control mail-indexing-batch mail-indexing-live mail-memory-submit mail-memory-events mail-memory-feedback mail-label-submit mail-label-events; do
+    queue_total=0
+    for state_name in wait active paused; do
+      state_count=$(redis-cli -n 0 LLEN "bull:$queue_name:$state_name")
+      queue_total=$((queue_total + state_count))
+    done
+    for state_name in delayed completed failed prioritized waiting-children repeat; do
+      state_count=$(redis-cli -n 0 ZCARD "bull:$queue_name:$state_name")
+      queue_total=$((queue_total + state_count))
+    done
+    echo "$queue_name=$queue_total"
+    total=$((total + queue_total))
+  done
+  echo "all_queued_jobs=$total"
+  [ "$total" -eq 0 ]
+')
+
+compose run --rm --no-deps --entrypoint /bin/sh minio-init -c '
+  set -eu
+  mc alias set invook http://minio:9000 "$S3_ACCESS_KEY_ID" "$S3_SECRET_ACCESS_KEY" >/dev/null
+  mc stat "invook/$S3_BUCKET" >/dev/null
+  listing_file=/tmp/invook-reset-object-listing
+  mc ls --recursive --json "invook/$S3_BUCKET" >"$listing_file"
+  [ ! -s "$listing_file" ]
+'
+
+echo "Reset evidence:"
+echo "$database_evidence"
+echo "all_public_product_rows=0"
+echo "drizzle_migrations_preserved=$migration_count_after"
+echo "redis_keys_after_flush=$redis_keys_after_flush"
+echo "$queue_evidence"
+echo "mailbox_objects=0"
+echo "Local reset complete. Open http://localhost:3000 to start a new Google signup."

--- a/docs/local-development-reset.md
+++ b/docs/local-development-reset.md
@@ -16,6 +16,6 @@ Before mutation, the command stops `web`, `api` and `worker` and verifies that t
 
 It does not drop PostgreSQL schemas or the `drizzle.__drizzle_migrations` table, delete the MinIO bucket, remove Docker named volumes, or change `.env.local`, credentials, configuration, migrations or source files.
 
-After clearing the stores, the command rebuilds and restarts the normal stack. It fails unless all product tables, requested BullMQ job states and mailbox objects remain empty after restart, and unless the Drizzle migration row count is unchanged. Its final output includes zero counts for profiles, connected accounts, messages, embeddings, drafts, memories, workflows and queued jobs.
+After clearing the stores, the command verifies the zero-data state while API, web, and worker services are still stopped, so an authenticated inbound webhook cannot race the destructive operation's result. It fails unless all product tables, requested BullMQ job states and mailbox objects are empty and the Drizzle migration row count is unchanged. It then rebuilds and restarts the normal stack. Its final output includes zero counts for profiles, connected accounts, messages, embeddings, drafts, memories, workflows and queued jobs.
 
 Open [http://localhost:3000](http://localhost:3000) after completion. A clean state presents the `Sign in with Google` entry action. The reset does not perform Google OAuth or create mailbox data.

--- a/docs/local-development-reset.md
+++ b/docs/local-development-reset.md
@@ -1,0 +1,21 @@
+# Reset local signup and mailbox data
+
+Use the local reset when the Docker development stack must return to a clean, new-signup state:
+
+```bash
+make reset-local
+```
+
+The command is intentionally destructive only inside the known `invook` local Docker Compose stack. It requires the default localhost PostgreSQL, Redis database 0, MinIO endpoint and `invook-mail` bucket; the expected service set, ports, internal endpoints and named-volume mounts; and an explicit confirmation token supplied by the Make target. It refuses to run when any of those guards differ.
+
+Before mutation, the command stops `web`, `api` and `worker` and verifies that they are no longer running. It then:
+
+- truncates every Invook product table in PostgreSQL's `public` schema;
+- flushes Redis database 0, which removes BullMQ job and execution state;
+- removes every object from the unversioned `invook-mail` MinIO bucket.
+
+It does not drop PostgreSQL schemas or the `drizzle.__drizzle_migrations` table, delete the MinIO bucket, remove Docker named volumes, or change `.env.local`, credentials, configuration, migrations or source files.
+
+After clearing the stores, the command rebuilds and restarts the normal stack. It fails unless all product tables, requested BullMQ job states and mailbox objects remain empty after restart, and unless the Drizzle migration row count is unchanged. Its final output includes zero counts for profiles, connected accounts, messages, embeddings, drafts, memories, workflows and queued jobs.
+
+Open [http://localhost:3000](http://localhost:3000) after completion. A clean state presents the `Sign in with Google` entry action. The reset does not perform Google OAuth or create mailbox data.

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "start": "pnpm --filter @invook/web run start",
     "api": "pnpm --filter @invook/api run start",
     "worker": "pnpm --filter @invook/worker run start",
-    "typecheck": "pnpm --recursive run typecheck",
+    "typecheck": "pnpm run typecheck:local-reset && pnpm --recursive run typecheck",
+    "typecheck:local-reset": "tsc --noEmit --strict --target ES2022 --module ESNext --moduleResolution Bundler --types node --allowImportingTsExtensions docker/reset-local-config.ts docker/reset-local-config.test.ts",
     "lint": "pnpm --recursive --if-present run lint",
-    "test": "pnpm --recursive --if-present run test",
+    "test": "pnpm run test:local-reset && pnpm --recursive --if-present run test",
+    "test:local-reset": "node --import tsx --test docker/reset-local-config.test.ts",
     "db:generate": "pnpm --filter @invook/database run db:generate",
     "db:migrate": "pnpm --filter @invook/database run db:migrate",
     "db:studio": "pnpm --filter @invook/database run db:studio"
@@ -24,6 +26,8 @@
     "pnpm": ">=11"
   },
   "devDependencies": {
+    "@types/node": "^24.0.0",
+    "tsx": "^4.20.0",
     "typescript": "^5.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.3
+      tsx:
+        specifier: ^4.20.0
+        version: 4.23.11
       typescript:
         specifier: ^5.9.0
         version: 5.9.3


### PR DESCRIPTION
## Summary

- add make reset-local for an explicit, repeatable local signup and mailbox reset
- fail closed unless PostgreSQL, Redis DB 0, MinIO, Compose services, ports, endpoints, labels, and named volumes match the known local Invook stack
- stop app services before mutation, preserve schemas, Drizzle history, the MinIO bucket, Docker volumes, configuration, credentials, and source, then rebuild and restart normally
- add strict TypeScript guard coverage and document the exact destructive scope

## Authorized local reset evidence

Before the first reset: 2 profiles, 2 connected accounts, 30,340 messages, 12,573 embeddings, 5 memories, 163,508 workflow steps, 2,176 Redis keys, and 32,929 MinIO objects.

After the reset and a repeat run through the delivered command: profiles=0, connected_accounts=0, messages=0, message_embeddings=0, drafts=0, gmail_drafts=0, memory_entries=0, workflow_steps=0, queue_outbox=0, all_public_product_rows=0, all_queued_jobs=0 across all ten BullMQ queues, mailbox_objects=0, redis_keys_after_flush=0, and drizzle_migrations_preserved=19.

The in-app browser showed the Invook new-signup entry screen at http://localhost:3000 with an enabled Sign in with Google button and no Inbox. Google OAuth was not started and no mailbox data was fabricated.

## Verification

- make reset-local
- make verify
- pnpm typecheck:local-reset
- pnpm test:local-reset (8 passing guard tests)
- docker compose -f docker/compose.yml config --quiet
- shell syntax, executable mode, diff checks, and forbidden API/destructive-volume scan