### PR TITLE
Ignore Gmail pushes for disconnected accounts

### DIFF
--- a/docs/gmail-replica-contract.md
+++ b/docs/gmail-replica-contract.md
@@ -51,7 +51,7 @@ A permanent Google credential rejection immediately marks the account `reconnect
 
 ## Continuous synchronization
 
-Google Pub/Sub sends authenticated OIDC push requests to `/v1/webhooks/google-pubsub`. The API validates the token audience, verified service-account email, and exact subscription. It commits the unique Pub/Sub message ID and a catch-up workflow step before returning `204`.
+Google Pub/Sub sends authenticated OIDC push requests to `/v1/webhooks/google-pubsub`. The API validates the token audience, verified service-account email, and exact subscription. A notification for an active connected account commits the unique Pub/Sub message ID and a catch-up workflow step before returning `204`. A notification without a matching connected account is acknowledged without retaining its email address or raw payload.
 
 The worker serializes Gmail control work per account with a PostgreSQL advisory lock while allowing different accounts to progress concurrently, and always rereads the stored replica cursor. Duplicate and out-of-order deliveries are safe because history application uses an expected-cursor comparison and idempotent provider identifiers. Message/tombstone/label membership changes, cursor advancement, push-event completion, and the durable mailbox-change event commit in one PostgreSQL transaction. The web client listens to authenticated `/v1/mailbox/events` SSE and refreshes on committed mailbox changes.
 

--- a/packages/database/src/gmail-push-events.test.ts
+++ b/packages/database/src/gmail-push-events.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { v4 as uuidv4 } from "uuid";
+
+import { ingestGmailPushEvent } from "./replica";
+import { gmailPushEvents } from "./schema";
+import * as schema from "./schema";
+
+const testDatabaseUrl = process.env.TEST_DATABASE_URL;
+
+test(
+  "Gmail pushes without a connected account are acknowledged without storage",
+  { skip: !testDatabaseUrl },
+  async () => {
+    if (!testDatabaseUrl) return;
+    const client = postgres(testDatabaseUrl, { max: 1, prepare: false });
+    const database = drizzle(client, { schema });
+    const providerEventId = `unmatched-${uuidv4()}`;
+    try {
+      const result = await ingestGmailPushEvent(
+        {
+          providerEventId,
+          emailAddress: `${uuidv4()}@example.com`,
+          notificationHistoryId: "100",
+          subscription: "projects/invook/subscriptions/gmail-mailbox-changes",
+          publishedAt: new Date(),
+          payload: { message: { messageId: providerEventId } },
+        },
+        database,
+      );
+
+      assert.deepEqual(result, { status: "ignored", accountId: null });
+      assert.deepEqual(
+        await database
+          .select({ id: gmailPushEvents.id })
+          .from(gmailPushEvents)
+          .where(eq(gmailPushEvents.providerEventId, providerEventId)),
+        [],
+      );
+    } finally {
+      await database
+        .delete(gmailPushEvents)
+        .where(eq(gmailPushEvents.providerEventId, providerEventId));
+      await client.end();
+    }
+  },
+);

--- a/packages/database/src/replica.ts
+++ b/packages/database/src/replica.ts
@@ -506,7 +506,10 @@ export async function ingestGmailPushEvent(
     payload: Record<string, unknown>;
   },
   database: Database = getDatabase(),
-): Promise<{ duplicate: boolean; accountId: string | null }> {
+): Promise<
+  | { status: "ignored"; accountId: null }
+  | { status: "duplicate" | "stored"; accountId: string }
+> {
   return database.transaction(async (transaction) => {
     const [account] = await transaction
       .select({ id: connectedAccounts.id, userId: connectedAccounts.userId })
@@ -519,29 +522,29 @@ export async function ingestGmailPushEvent(
         ),
       )
       .limit(1);
+    if (!account) return { status: "ignored", accountId: null };
+
     const [event] = await transaction
       .insert(gmailPushEvents)
       .values({
         ...input,
-        accountId: account?.id ?? null,
+        accountId: account.id,
       })
       .onConflictDoNothing({ target: gmailPushEvents.providerEventId })
       .returning({ id: gmailPushEvents.id });
-    if (!event) return { duplicate: true, accountId: account?.id ?? null };
+    if (!event) return { status: "duplicate", accountId: account.id };
 
-    if (account) {
-      await enqueueWorkflowStep(
-        {
-          userId: account.userId,
-          accountId: account.id,
-          stepType: "gmail.history.catchup",
-          payload: { pushEventId: event.id },
-          idempotencyKey: `gmail-history-push:${event.id}`,
-        },
-        transaction as unknown as Database,
-      );
-    }
-    return { duplicate: false, accountId: account?.id ?? null };
+    await enqueueWorkflowStep(
+      {
+        userId: account.userId,
+        accountId: account.id,
+        stepType: "gmail.history.catchup",
+        payload: { pushEventId: event.id },
+        idempotencyKey: `gmail-history-push:${event.id}`,
+      },
+      transaction as unknown as Database,
+    );
+    return { status: "stored", accountId: account.id };
   });
 }
 


### PR DESCRIPTION
## Summary
- acknowledge authenticated Gmail Pub/Sub notifications that do not match an active connected account without storing email addresses or raw payloads
- retain durable deduplication and history catch-up for matched connected accounts
- document the ownership boundary and add a real PostgreSQL regression test

## Verification
- make verify
- TEST_DATABASE_URL=postgresql://invook:invook@127.0.0.1:54322/invook pnpm --filter @invook/database exec node --import tsx --test src/gmail-push-events.test.ts
- docker compose --env-file .env.local -f docker/compose.yml config --quiet