### PR TITLE
Fix Settings navigation layout

### DIFF
--- a/apps/web/src/app/mail/page.tsx
+++ b/apps/web/src/app/mail/page.tsx
@@ -138,7 +138,6 @@ export default async function MailPage({ searchParams }: MailPageProps) {
   if (selectedThread) {
     centerPane = (
       <ThreadReader
-        key={selectedThread.id}
         thread={selectedThread}
         currentView={currentView}
         mailboxCursor={mailboxCursor}
@@ -192,7 +191,12 @@ export default async function MailPage({ searchParams }: MailPageProps) {
           syncProgress={workspace.account.mailSyncProgress}
           labels={workspace.labels}
         />
-        {centerPane}
+        <div
+          data-slot="mail-workspace-content"
+          className="min-h-0 min-w-0 overflow-hidden [&>*]:h-full"
+        >
+          {centerPane}
+        </div>
         <AgentPanel
           key={selectedThread?.id ?? "mailbox"}
           openThreadId={selectedThread?.id}


### PR DESCRIPTION
## Summary
- keep the mail workspace center pane inside a stable grid slot
- remove the page-level thread key that allowed stale thread content to survive a concurrent refresh
- preserve thread-specific client state resets in the focused child components

## Verification
- `make verify`
- `docker compose --env-file /Users/abhishekucs/Documents/TestOrg/Engineering/.env.local -f docker/compose.yml config --quiet`
- rebuilt the local Docker web stack
- opened the reported thread and switched to Settings during active Gmail sync
- confirmed the final grid has exactly three children, one Settings heading, and zero stale open-thread regions