### PR TITLE
Add settings dialog and live mailbox pipeline status

### DIFF
--- a/apps/api/src/routes/account-sync-events.ts
+++ b/apps/api/src/routes/account-sync-events.ts
@@ -2,6 +2,7 @@ import type { FastifyPluginAsync, FastifyReply } from "fastify";
 
 import type { AccountSyncStatusEvent } from "@invook/contracts";
 import {
+  getAccountSyncStateForAccount,
   getIndexingProgressForAccount,
   getIndexingProgressForUser,
   getMailSyncProgressForAccount,
@@ -33,15 +34,18 @@ export const registerAccountSyncEventRoutes: FastifyPluginAsync = async (api) =>
   const getDurableProgress = async (
     accountId: string,
   ): Promise<AccountSyncStatusEvent | null> => {
-    const [mailSync, indexing] = await Promise.all([
+    const [mailSync, indexing, syncState] = await Promise.all([
       getMailSyncProgressForAccount({ accountId }),
       getIndexingProgressForAccount({
         accountId,
         modelId,
         indexVersion: MAIL_INDEX_VERSION,
       }),
+      getAccountSyncStateForAccount({ accountId }),
     ]);
-    return mailSync && indexing ? { mailSync, indexing } : null;
+    return mailSync && indexing && syncState
+      ? { mailSync, indexing, memory: syncState.memory }
+      : null;
   };
   const broadcastDurableProgress = async (accountId: string) => {
     const progress = await getDurableProgress(accountId);
@@ -87,10 +91,11 @@ export const registerAccountSyncEventRoutes: FastifyPluginAsync = async (api) =>
         await sendProblem(request, reply, 404, "Connected Gmail account not found");
         return;
       }
-      const mailSync = await getMailSyncProgressForAccount({
-        accountId: indexing.accountId,
-      });
-      if (!mailSync) {
+      const [mailSync, syncState] = await Promise.all([
+        getMailSyncProgressForAccount({ accountId: indexing.accountId }),
+        getAccountSyncStateForAccount({ accountId: indexing.accountId }),
+      ]);
+      if (!mailSync || !syncState) {
         await sendProblem(request, reply, 404, "Connected Gmail account not found");
         return;
       }
@@ -114,7 +119,11 @@ export const registerAccountSyncEventRoutes: FastifyPluginAsync = async (api) =>
       };
       request.raw.once("close", removeStream);
       reply.raw.once("close", removeStream);
-      writeEvent(reply.raw, { mailSync, indexing: indexing.progress });
+      writeEvent(reply.raw, {
+        mailSync,
+        indexing: indexing.progress,
+        memory: syncState.memory,
+      });
     },
   );
 };

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,7 +26,8 @@
     "sanitize-html": "^2.17.6",
     "shadcn": "^4.16.2",
     "tailwind-merge": "^3.4.0",
-    "uuid": "^14.0.1"
+    "uuid": "^14.0.1",
+    "zustand": "^5.0.15"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",

--- a/apps/web/src/app/mail/page.tsx
+++ b/apps/web/src/app/mail/page.tsx
@@ -7,7 +7,6 @@ import { validate as validateUuid } from "uuid";
 import { mailboxViews } from "@invook/contracts";
 
 import { AgentPanel } from "@/components/mail/agent-panel";
-import { AccountSyncEventSubscriber } from "@/components/mail/account-sync-event-subscriber";
 import { ComposeSurface } from "@/components/mail/compose-surface";
 import { MailList } from "@/components/mail/mail-list";
 import { MailboxEventSubscriber } from "@/components/mail/mailbox-event-subscriber";
@@ -25,7 +24,6 @@ import {
   PendingSurface,
   SearchResultsSurface,
   SearchSurface,
-  SettingsSurface,
 } from "@/components/mail/workspace-surface";
 import { getMailboxWorkspace, searchMailbox } from "@/lib/api";
 
@@ -45,7 +43,6 @@ const mailSurfaces = new Set<MailSurface>([
   "mail",
   "compose",
   "search",
-  "settings",
   "automations",
 ]);
 
@@ -151,16 +148,6 @@ export default async function MailPage({ searchParams }: MailPageProps) {
     centerPane = <SearchSurface />;
   } else if (currentSurface === "search" && query) {
     centerPane = <SearchResultsSurface query={query} results={searchResults} />;
-  } else if (currentSurface === "settings") {
-    centerPane = (
-      <SettingsSurface
-        memories={workspace.memories}
-        syncState={workspace.account.syncState.memory}
-        aiConfigured={workspace.aiConfigured}
-        labels={workspace.labels}
-        batchConfigured={workspace.batchConfigured}
-      />
-    );
   } else if (currentSurface === "automations") {
     centerPane = <PendingSurface />;
   } else {
@@ -181,15 +168,16 @@ export default async function MailPage({ searchParams }: MailPageProps) {
 
   return (
     <main className="h-dvh overflow-hidden bg-background">
-      <AccountSyncEventSubscriber />
       <MailboxEventSubscriber />
       <div className="grid h-full grid-cols-[64px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(520px,1fr)_360px]">
         <MailSidebar
-          email={workspace.account.email}
+          account={workspace.account}
           currentView={currentView}
           currentSurface={currentSurface}
-          syncProgress={workspace.account.mailSyncProgress}
+          memories={workspace.memories}
           labels={workspace.labels}
+          aiConfigured={workspace.aiConfigured}
+          batchConfigured={workspace.batchConfigured}
         />
         <div
           data-slot="mail-workspace-content"
@@ -202,7 +190,6 @@ export default async function MailPage({ searchParams }: MailPageProps) {
           openThreadId={selectedThread?.id}
           openThreadSubject={selectedThread?.subject || undefined}
           aiConfigured={workspace.aiConfigured}
-          indexingProgress={workspace.account.indexingProgress}
         />
       </div>
     </main>

--- a/apps/web/src/components/mail/account-pipeline-progress.tsx
+++ b/apps/web/src/components/mail/account-pipeline-progress.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  Alert02Icon,
+  Brain02Icon,
+  CloudSyncIcon,
+  Loading01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type { AccountSyncStatusEvent } from "@invook/contracts";
+
+import { Progress } from "@/components/ui/progress";
+import { useAccountSyncEvents } from "@/hooks/use-account-sync-events";
+import { cn } from "@/lib/utils";
+
+import { getAccountPipelinePresentation } from "./account-pipeline-state";
+
+export interface AccountPipelineProgressProps {
+  initialProgress: AccountSyncStatusEvent;
+}
+
+export function AccountPipelineProgress({
+  initialProgress,
+}: AccountPipelineProgressProps) {
+  const progress = useAccountSyncEvents(initialProgress);
+  const presentation = getAccountPipelinePresentation(progress);
+  if (!presentation) return null;
+
+  const icon = presentation.isFailed
+    ? Alert02Icon
+    : presentation.phase === "mail"
+      ? CloudSyncIcon
+      : presentation.phase === "indexing"
+        ? Loading01Icon
+        : Brain02Icon;
+
+  return (
+    <div
+      role={presentation.isFailed ? "alert" : "status"}
+      aria-live="polite"
+      className="hidden px-2 pb-1 lg:block"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            className={cn(
+              "grid shrink-0 text-primary",
+              presentation.phase === "indexing" && !presentation.isFailed && "motion-safe:animate-spin",
+              presentation.isFailed && "text-destructive",
+            )}
+          >
+            <HugeiconsIcon icon={icon} size={14} strokeWidth={1.7} />
+          </span>
+          <p className="truncate text-[13px] font-semibold text-sidebar-foreground">
+            {presentation.title}
+          </p>
+        </div>
+        {presentation.percentage !== null ? (
+          <span className="text-xs tabular-nums text-sidebar-foreground/55">
+            {presentation.percentage}%
+          </span>
+        ) : null}
+      </div>
+      <Progress
+        value={presentation.percentage}
+        aria-label={presentation.title}
+        className={cn(
+          "mt-2 h-1 bg-sidebar-accent",
+          presentation.isFailed && "[&_[data-slot=progress-indicator]]:bg-destructive",
+        )}
+      />
+      <p className="mt-2 text-xs leading-4 text-sidebar-foreground/48">
+        {presentation.detail}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/mail/account-pipeline-state.test.ts
+++ b/apps/web/src/components/mail/account-pipeline-state.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getAccountPipelinePresentation,
+  parseAccountSyncStatusEvent,
+} from "./account-pipeline-state";
+
+const completeMailSync = {
+  state: "complete",
+  discoveryComplete: true,
+  discoveredMessageCount: 71_468,
+  processedMessageCount: 71_468,
+  failedMessageCount: 0,
+} as const;
+
+test("account progress events are validated before entering client state", () => {
+  const serialized = JSON.stringify({
+    mailSync: completeMailSync,
+    indexing: {
+      state: "running",
+      completedMessageCount: 4_000,
+      failedMessageCount: 0,
+      totalMessageCount: 71_468,
+    },
+    memory: "pending",
+  });
+
+  assert.deepEqual(parseAccountSyncStatusEvent(serialized), JSON.parse(serialized));
+  assert.equal(parseAccountSyncStatusEvent("{"), null);
+  assert.equal(
+    parseAccountSyncStatusEvent(JSON.stringify({ ...JSON.parse(serialized), memory: "unknown" })),
+    null,
+  );
+});
+
+test("the sidebar presents only the earliest incomplete pipeline phase", () => {
+  const indexing = {
+    state: "running",
+    completedMessageCount: 4_000,
+    failedMessageCount: 0,
+    totalMessageCount: 20_000,
+  } as const;
+  assert.deepEqual(
+    getAccountPipelinePresentation({
+      mailSync: completeMailSync,
+      indexing,
+      memory: "running",
+    }),
+    {
+      phase: "indexing",
+      title: "Indexing mail",
+      detail: "4,000 of 20,000 messages indexed",
+      percentage: 20,
+      isFailed: false,
+    },
+  );
+  assert.deepEqual(
+    getAccountPipelinePresentation({
+      mailSync: completeMailSync,
+      indexing: { ...indexing, state: "complete", completedMessageCount: 20_000 },
+      memory: "running",
+    }),
+    {
+      phase: "memory",
+      title: "Creating Memory",
+      detail: "Analyzing sent mail for reusable reply rules",
+      percentage: null,
+      isFailed: false,
+    },
+  );
+});
+
+test("a completed account pipeline leaves the sidebar clean", () => {
+  assert.equal(
+    getAccountPipelinePresentation({
+      mailSync: completeMailSync,
+      indexing: {
+        state: "complete",
+        completedMessageCount: 71_468,
+        failedMessageCount: 0,
+        totalMessageCount: 71_468,
+      },
+      memory: "complete",
+    }),
+    null,
+  );
+});

--- a/apps/web/src/components/mail/account-pipeline-state.ts
+++ b/apps/web/src/components/mail/account-pipeline-state.ts
@@ -1,0 +1,143 @@
+import type {
+  AccountSyncStage,
+  AccountSyncStatusEvent,
+  IndexingProgress,
+  MailSyncProgress,
+} from "@invook/contracts";
+
+import { getGmailSyncProgressPresentation } from "./gmail-sync-progress";
+
+export interface AccountPipelinePresentation {
+  phase: "mail" | "indexing" | "memory";
+  title: string;
+  detail: string;
+  percentage: number | null;
+  isFailed: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isAccountSyncStage(value: unknown): value is AccountSyncStage {
+  return value === "pending" || value === "running" || value === "complete" || value === "failed";
+}
+
+function isNonnegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function parseMailSyncProgress(value: unknown): MailSyncProgress | null {
+  if (
+    !isRecord(value) ||
+    !isAccountSyncStage(value.state) ||
+    typeof value.discoveryComplete !== "boolean" ||
+    !isNonnegativeInteger(value.discoveredMessageCount) ||
+    !isNonnegativeInteger(value.processedMessageCount) ||
+    !isNonnegativeInteger(value.failedMessageCount)
+  ) {
+    return null;
+  }
+
+  return {
+    state: value.state,
+    discoveryComplete: value.discoveryComplete,
+    discoveredMessageCount: value.discoveredMessageCount,
+    processedMessageCount: value.processedMessageCount,
+    failedMessageCount: value.failedMessageCount,
+  };
+}
+
+function parseIndexingProgress(value: unknown): IndexingProgress | null {
+  if (
+    !isRecord(value) ||
+    !isAccountSyncStage(value.state) ||
+    !isNonnegativeInteger(value.completedMessageCount) ||
+    !isNonnegativeInteger(value.failedMessageCount) ||
+    !isNonnegativeInteger(value.totalMessageCount)
+  ) {
+    return null;
+  }
+
+  return {
+    state: value.state,
+    completedMessageCount: value.completedMessageCount,
+    failedMessageCount: value.failedMessageCount,
+    totalMessageCount: value.totalMessageCount,
+  };
+}
+
+export function parseAccountSyncStatusEvent(
+  serializedEvent: string,
+): AccountSyncStatusEvent | null {
+  try {
+    const value: unknown = JSON.parse(serializedEvent);
+    if (!isRecord(value) || !isAccountSyncStage(value.memory)) return null;
+    const mailSync = parseMailSyncProgress(value.mailSync);
+    const indexing = parseIndexingProgress(value.indexing);
+    return mailSync && indexing
+      ? { mailSync, indexing, memory: value.memory }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getAccountPipelinePresentation(
+  progress: AccountSyncStatusEvent,
+): AccountPipelinePresentation | null {
+  const mailPresentation = getGmailSyncProgressPresentation(progress.mailSync);
+  if (mailPresentation) {
+    return { phase: "mail", ...mailPresentation };
+  }
+
+  if (progress.indexing.state !== "complete") {
+    const { indexing } = progress;
+    const isFailed = indexing.state === "failed";
+    const percentage = indexing.totalMessageCount > 0
+      ? Math.min(
+          100,
+          Math.round(
+            (indexing.completedMessageCount / indexing.totalMessageCount) * 100,
+          ),
+        )
+      : null;
+    const failedDetail = indexing.failedMessageCount > 0
+      ? `; ${indexing.failedMessageCount.toLocaleString()} failed`
+      : "";
+    return {
+      phase: "indexing",
+      title: isFailed
+        ? "Indexing needs attention"
+        : indexing.state === "running"
+          ? "Indexing mail"
+          : "Preparing mail index",
+      detail: indexing.totalMessageCount > 0
+        ? `${indexing.completedMessageCount.toLocaleString()} of ${indexing.totalMessageCount.toLocaleString()} messages indexed${failedDetail}`
+        : "Waiting for indexed messages",
+      percentage,
+      isFailed,
+    };
+  }
+
+  if (progress.memory !== "complete") {
+    const isFailed = progress.memory === "failed";
+    return {
+      phase: "memory",
+      title: isFailed
+        ? "Memory needs attention"
+        : progress.memory === "running"
+          ? "Creating Memory"
+          : "Preparing Memory",
+      detail: isFailed
+        ? "Memory analysis could not finish"
+        : progress.memory === "running"
+          ? "Analyzing sent mail for reusable reply rules"
+          : "Waiting for Memory analysis to start",
+      percentage: null,
+      isFailed,
+    };
+  }
+
+  return null;
+}

--- a/apps/web/src/components/mail/account-sync-event-subscriber.tsx
+++ b/apps/web/src/components/mail/account-sync-event-subscriber.tsx
@@ -1,8 +1,0 @@
-"use client";
-
-import { useAccountSyncEvents } from "@/hooks/use-account-sync-events";
-
-export function AccountSyncEventSubscriber() {
-  useAccountSyncEvents();
-  return null;
-}

--- a/apps/web/src/components/mail/agent-panel.tsx
+++ b/apps/web/src/components/mail/agent-panel.tsx
@@ -2,20 +2,14 @@
 
 import { useChat } from "@ai-sdk/react";
 import {
-  Alert02Icon,
   ArrowUpRight01Icon,
   BotIcon,
-  Clock01Icon,
-  Loading01Icon,
   PencilEdit01Icon,
   Search02Icon,
   SparklesIcon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import type {
-  IndexingProgress,
-  MailboxActionProposal,
-} from "@invook/contracts";
+import type { MailboxActionProposal } from "@invook/contracts";
 import { DefaultChatTransport, type UIDataTypes, type UIMessage } from "ai";
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -37,75 +31,16 @@ type MailAgentUIMessage = UIMessage<
   }
 >;
 
-interface IndexingStatusProps {
-  progress: IndexingProgress;
-}
-
-function IndexingStatus({ progress }: IndexingStatusProps) {
-  const { state } = progress;
-  if (state === "complete") return null;
-
-  const running = state === "running";
-  const failed = state === "failed";
-  const title = failed
-    ? "Indexing paused"
-    : running
-      ? "Indexing your mail"
-      : "Indexing pending";
-  const detail = failed
-    ? progress.totalMessageCount > 0
-      ? `${progress.completedMessageCount.toLocaleString()} of ${progress.totalMessageCount.toLocaleString()} messages indexed${progress.failedMessageCount > 0 ? `; ${progress.failedMessageCount.toLocaleString()} failed` : ""}. Full-text search still works.`
-      : "Indexing is unavailable until mailbox synchronization recovers."
-    : running
-      ? `${progress.completedMessageCount.toLocaleString()} of ${progress.totalMessageCount.toLocaleString()} messages indexed.`
-      : progress.totalMessageCount > 0
-        ? `${progress.totalMessageCount.toLocaleString()} messages are waiting to be indexed.`
-        : "Semantic search is not ready yet.";
-  const icon = failed ? Alert02Icon : running ? Loading01Icon : Clock01Icon;
-
-  return (
-    <div
-      role={failed ? "alert" : "status"}
-      aria-live="polite"
-      className={cn(
-        "rounded-lg bg-primary/[0.07] px-3 py-2.5",
-        failed && "bg-destructive/[0.08]",
-      )}
-    >
-      <div className="flex items-start gap-2.5">
-        <span
-          className={cn(
-            "grid size-7 shrink-0 place-items-center rounded-md bg-primary/10 text-primary",
-            failed && "bg-destructive/10 text-destructive",
-          )}
-        >
-          <span className={cn("grid", running && "motion-safe:animate-spin")}>
-            <HugeiconsIcon icon={icon} size={14} strokeWidth={1.8} />
-          </span>
-        </span>
-        <div className="min-w-0 pt-0.5">
-          <p className="text-xs font-semibold text-foreground/88">{title}</p>
-          <p className="mt-0.5 text-[11px] leading-4 text-muted-foreground">
-            {detail}
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export interface AgentPanelProps {
   openThreadId?: string;
   openThreadSubject?: string;
   aiConfigured: boolean;
-  indexingProgress: IndexingProgress;
 }
 
 export function AgentPanel({
   openThreadId,
   openThreadSubject,
   aiConfigured,
-  indexingProgress,
 }: AgentPanelProps) {
   const transport = useMemo(
     () =>
@@ -176,17 +111,16 @@ export function AgentPanel({
         </Button>
       </header>
 
-      <div className="mx-3 space-y-2">
-        <IndexingStatus progress={indexingProgress} />
-        {openThreadSubject ? (
+      {openThreadSubject ? (
+        <div className="mx-3">
           <div className="rounded-lg bg-background/45 px-3 py-2.5">
             <p className="text-xs font-medium text-muted-foreground">Current thread</p>
             <p className="mt-1 truncate text-[13px] text-foreground/82">
               {formatMailText(openThreadSubject)}
             </p>
           </div>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
         {messages.length === 0 ? (

--- a/apps/web/src/components/mail/mail-list.tsx
+++ b/apps/web/src/components/mail/mail-list.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 
 import { formatMailDate, formatMailText, threadPeople } from "./mail-format";
 import { MailboxRefreshButton } from "./mailbox-refresh-button";
+import { MailNavigationPending } from "./mail-navigation-pending";
 import type {
   MailAccount,
   MailboxView,
@@ -85,6 +86,7 @@ function MailRow({
         unread && "bg-card/45",
       )}
     >
+      <MailNavigationPending variant="edge" />
       <div className="flex min-w-0 items-center gap-2">
         {important ? <span className="size-1.5 shrink-0 rounded-full bg-primary" /> : null}
         <p className={cn("truncate text-sm", unread ? "font-semibold" : "font-medium text-foreground/78")}>

--- a/apps/web/src/components/mail/mail-navigation-pending.tsx
+++ b/apps/web/src/components/mail/mail-navigation-pending.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Loading01Icon } from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useLinkStatus } from "next/link";
+
+import { cn } from "@/lib/utils";
+
+export interface MailNavigationPendingProps {
+  variant?: "inline" | "edge";
+}
+
+export function MailNavigationPending({
+  variant = "inline",
+}: MailNavigationPendingProps) {
+  const { pending } = useLinkStatus();
+
+  if (variant === "edge") {
+    return (
+      <span
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-y-1 left-0 w-0.5 rounded-full bg-primary opacity-0 transition-opacity",
+          pending && "opacity-100 motion-safe:animate-pulse",
+        )}
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "ml-auto hidden size-3.5 shrink-0 place-items-center text-sidebar-foreground/60 opacity-0 lg:grid",
+        pending && "opacity-100 motion-safe:animate-spin",
+      )}
+    >
+      <HugeiconsIcon icon={Loading01Icon} size={13} />
+    </span>
+  );
+}

--- a/apps/web/src/components/mail/mail-sidebar.tsx
+++ b/apps/web/src/components/mail/mail-sidebar.tsx
@@ -1,6 +1,5 @@
 import {
   Airplane01Icon,
-  CloudSyncIcon,
   Delete02Icon,
   FileEditIcon,
   HonourStarIcon,
@@ -12,33 +11,38 @@ import {
   PencilEdit01Icon,
   Search02Icon,
   SentIcon,
-  Settings01Icon,
   StarIcon,
   Tag01Icon,
   WorkflowSquare01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import type {
+  MailboxAccount,
   MailLabel,
-  MailSyncProgress,
+  MemoryEntry,
   SystemLabelKey,
 } from "@invook/contracts";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
-import { Progress } from "@/components/ui/progress";
+import { SettingsDialog } from "@/components/settings/settings-dialog";
 import { cn } from "@/lib/utils";
 
+import { AccountPipelineProgress } from "./account-pipeline-progress";
 import { initials } from "./mail-format";
-import { getGmailSyncProgressPresentation } from "./gmail-sync-progress";
+import { MailNavigationPending } from "./mail-navigation-pending";
 import type { MailboxView, MailSurface } from "./types";
 
 const workspaceItems = [
   { label: "Compose", icon: PencilEdit01Icon, surface: "compose" },
   { label: "Search", icon: Search02Icon, surface: "search" },
-  { label: "Settings", icon: Settings01Icon, surface: "settings" },
-  { label: "Automations", icon: WorkflowSquare01Icon, surface: "automations" },
 ] as const;
+
+const automationsItem = {
+  label: "Automations",
+  icon: WorkflowSquare01Icon,
+  surface: "automations",
+} as const;
 
 const labelIcons = {
   important: HonourStarIcon,
@@ -61,6 +65,14 @@ interface NavLinkProps {
   href: string;
 }
 
+function navItemClassName(active: boolean): string {
+  return cn(
+    "group flex h-9 w-full items-center gap-2.5 rounded-md px-2.5 text-sm font-medium text-sidebar-foreground/58 transition-colors",
+    "hover:bg-sidebar-accent/70 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+    active && "bg-sidebar-accent text-sidebar-foreground",
+  );
+}
+
 function NavLink({
   label,
   icon,
@@ -71,89 +83,43 @@ function NavLink({
     <Link
       href={href}
       aria-current={active ? "page" : undefined}
-      className={cn(
-        "group flex h-9 items-center gap-2.5 rounded-md px-2.5 text-sm font-medium text-sidebar-foreground/58 transition-colors",
-        "hover:bg-sidebar-accent/70 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
-        active && "bg-sidebar-accent text-sidebar-foreground",
-      )}
+      className={navItemClassName(active)}
     >
       <HugeiconsIcon icon={icon} size={15} strokeWidth={1.65} className="shrink-0" />
       <span className="hidden truncate lg:block">{label}</span>
+      <MailNavigationPending />
     </Link>
   );
 }
 
-interface GmailSyncProgressProps {
-  progress: MailSyncProgress;
-}
-
-function GmailSyncProgress({ progress }: GmailSyncProgressProps) {
-  const presentation = getGmailSyncProgressPresentation(progress);
-  if (!presentation) return null;
-  const { title, detail, percentage, isFailed } = presentation;
-
-  return (
-    <div
-      role={isFailed ? "alert" : "status"}
-      aria-live="polite"
-      className="hidden px-2 pb-1 lg:block"
-    >
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <HugeiconsIcon
-            icon={CloudSyncIcon}
-            size={14}
-            strokeWidth={1.7}
-            className={cn(
-              "shrink-0 text-primary",
-              isFailed && "text-destructive",
-            )}
-          />
-          <p className="truncate text-[13px] font-semibold text-sidebar-foreground">{title}</p>
-        </div>
-        {percentage !== null ? (
-          <span className="text-xs tabular-nums text-sidebar-foreground/55">
-            {percentage}%
-          </span>
-        ) : null}
-      </div>
-      <Progress
-        value={percentage}
-        aria-label={title}
-        className={cn(
-          "mt-2 h-1 bg-sidebar-accent",
-          isFailed && "[&_[data-slot=progress-indicator]]:bg-destructive",
-        )}
-      />
-      <p className="mt-2 text-xs leading-4 text-sidebar-foreground/48">{detail}</p>
-    </div>
-  );
-}
-
 export interface MailSidebarProps {
-  email: string;
+  account: MailboxAccount;
   currentView: MailboxView;
   currentSurface: MailSurface;
-  syncProgress: MailSyncProgress;
+  memories: MemoryEntry[];
   labels: MailLabel[];
+  aiConfigured: boolean;
+  batchConfigured: boolean;
 }
 
 export function MailSidebar({
-  email,
+  account,
   currentView,
   currentSurface,
-  syncProgress,
+  memories,
   labels,
+  aiConfigured,
+  batchConfigured,
 }: MailSidebarProps) {
   return (
     <aside className="flex min-h-0 flex-col bg-sidebar px-2 py-3 lg:px-3" aria-label="Mailbox navigation">
       <div className="flex h-11 items-center gap-2.5 px-1.5 lg:px-2">
         <span className="grid size-8 shrink-0 place-items-center rounded-full bg-sidebar-accent text-xs font-semibold text-sidebar-foreground">
-          {initials(email)}
+          {initials(account.email)}
         </span>
         <div className="hidden min-w-0 flex-1 lg:block">
           <p className="truncate text-sm font-semibold text-sidebar-foreground">Invook</p>
-          <p className="truncate text-xs text-sidebar-foreground/45">{email}</p>
+          <p className="truncate text-xs text-sidebar-foreground/45">{account.email}</p>
         </div>
         <form action="/v1/auth/sign-out" method="post" className="hidden lg:block">
           <Button
@@ -178,6 +144,20 @@ export function MailSidebar({
             href={`/mail?surface=${item.surface}`}
           />
         ))}
+        <SettingsDialog
+          account={account}
+          memories={memories}
+          labels={labels}
+          aiConfigured={aiConfigured}
+          batchConfigured={batchConfigured}
+          triggerClassName={navItemClassName(false)}
+        />
+        <NavLink
+          label={automationsItem.label}
+          icon={automationsItem.icon}
+          active={currentSurface === automationsItem.surface}
+          href={`/mail?surface=${automationsItem.surface}`}
+        />
       </nav>
 
       <div className="mt-5 min-h-0 flex-1 overflow-y-auto">
@@ -221,7 +201,13 @@ export function MailSidebar({
         </nav>
       </div>
 
-      <GmailSyncProgress progress={syncProgress} />
+      <AccountPipelineProgress
+        initialProgress={{
+          mailSync: account.mailSyncProgress,
+          indexing: account.indexingProgress,
+          memory: account.syncState.memory,
+        }}
+      />
     </aside>
   );
 }

--- a/apps/web/src/components/mail/types.ts
+++ b/apps/web/src/components/mail/types.ts
@@ -13,7 +13,7 @@ export type StaticMailboxView = Exclude<
 
 export type MailboxView = ContractMailboxView | `label:${string}`;
 
-export type MailSurface = "mail" | "compose" | "search" | "settings" | "automations";
+export type MailSurface = "mail" | "compose" | "search" | "automations";
 
 export type MailThreadSummary = MailboxThreadSummary;
 export type ThreadMessage = MailboxThreadMessage;

--- a/apps/web/src/components/mail/workspace-surface.tsx
+++ b/apps/web/src/components/mail/workspace-surface.tsx
@@ -4,16 +4,9 @@ import {
   WorkflowSquare01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import type {
-  AccountSyncStage,
-  MailLabel,
-  MailSearchResult,
-  MemoryEntry,
-} from "@invook/contracts";
+import type { MailSearchResult } from "@invook/contracts";
 import Link from "next/link";
 
-import { MemorySettings } from "@/components/settings/memory-settings";
-import { LabelSettings } from "@/components/settings/label-settings";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SurfaceHeader } from "@/components/mail/surface-header";
@@ -113,36 +106,6 @@ export function SearchResultsSurface({
             ))}
           </div>
         )}
-      </div>
-    </section>
-  );
-}
-
-export interface SettingsSurfaceProps {
-  memories: MemoryEntry[];
-  syncState: AccountSyncStage;
-  aiConfigured: boolean;
-  labels: MailLabel[];
-  batchConfigured: boolean;
-}
-
-export function SettingsSurface({
-  memories,
-  syncState,
-  aiConfigured,
-  labels,
-  batchConfigured,
-}: SettingsSurfaceProps) {
-  return (
-    <section className="flex min-h-0 flex-col bg-background">
-      <SurfaceHeader title="Settings" />
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <LabelSettings labels={labels} batchConfigured={batchConfigured} />
-        <MemorySettings
-          memories={memories}
-          syncState={syncState}
-          aiConfigured={aiConfigured}
-        />
       </div>
     </section>
   );

--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import {
+  Brain02Icon,
+  CreditCardIcon,
+  Settings01Icon,
+  TagsIcon,
+  UserAccountIcon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import type {
+  MailboxAccount,
+  MailLabel,
+  MemoryEntry,
+} from "@invook/contracts";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+
+import { LabelSettings } from "./label-settings";
+import { MemorySettings } from "./memory-settings";
+
+const settingsSections = [
+  { value: "account", label: "Account", icon: UserAccountIcon },
+  { value: "memory", label: "Memory", icon: Brain02Icon },
+  { value: "labels", label: "Labels", icon: TagsIcon },
+  { value: "billing", label: "Billing", icon: CreditCardIcon },
+] as const;
+
+interface AccountSettingsProps {
+  account: MailboxAccount;
+  aiConfigured: boolean;
+}
+
+function AccountSettings({ account, aiConfigured }: AccountSettingsProps) {
+  const replicaStatus = account.replica.state.replaceAll("_", " ");
+
+  return (
+    <section className="mx-auto w-full max-w-2xl px-6 py-8 sm:px-10 sm:py-10">
+      <h2 className="text-xl font-semibold tracking-[-0.03em]">Account</h2>
+      <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
+        Manage the Google account and local Invook session used by this mailbox.
+      </p>
+
+      <div className="mt-7 rounded-xl bg-card/65 p-5">
+        <div className="flex items-center gap-3">
+          <span className="grid size-10 shrink-0 place-items-center rounded-full bg-secondary text-sm font-semibold">
+            {account.email.slice(0, 1).toUpperCase()}
+          </span>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold">{account.email}</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">Google Gmail</p>
+          </div>
+        </div>
+
+        <dl className="mt-6 grid gap-3 text-sm sm:grid-cols-2">
+          <div className="rounded-lg bg-background/55 px-4 py-3">
+            <dt className="text-xs text-muted-foreground">Connection</dt>
+            <dd className="mt-1 font-medium capitalize">{account.status}</dd>
+          </div>
+          <div className="rounded-lg bg-background/55 px-4 py-3">
+            <dt className="text-xs text-muted-foreground">Mailbox replica</dt>
+            <dd className="mt-1 font-medium capitalize">{replicaStatus}</dd>
+          </div>
+          <div className="rounded-lg bg-background/55 px-4 py-3 sm:col-span-2">
+            <dt className="text-xs text-muted-foreground">AI features</dt>
+            <dd className="mt-1 font-medium">
+              {aiConfigured ? "Configured" : "Setup needed"}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <form action="/v1/auth/sign-out" method="post" className="mt-6">
+        <Button type="submit" variant="secondary">
+          Sign out of Invook
+        </Button>
+      </form>
+    </section>
+  );
+}
+
+function BillingSettings() {
+  return (
+    <section className="mx-auto w-full max-w-2xl px-6 py-8 sm:px-10 sm:py-10">
+      <h2 className="text-xl font-semibold tracking-[-0.03em]">Billing</h2>
+      <p className="mt-1.5 text-sm leading-6 text-muted-foreground">
+        Review the billing state attached to this Invook installation.
+      </p>
+
+      <div className="mt-7 rounded-xl bg-card/65 px-6 py-10 text-center">
+        <span className="mx-auto grid size-10 place-items-center rounded-xl bg-secondary text-muted-foreground">
+          <HugeiconsIcon icon={CreditCardIcon} size={18} />
+        </span>
+        <p className="mt-4 text-sm font-semibold">No billing plan is configured</p>
+        <p className="mx-auto mt-1.5 max-w-sm text-sm leading-6 text-muted-foreground">
+          This installation has no billing provider or paid plan attached.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export interface SettingsDialogProps {
+  account: MailboxAccount;
+  memories: MemoryEntry[];
+  labels: MailLabel[];
+  aiConfigured: boolean;
+  batchConfigured: boolean;
+  triggerClassName?: string;
+}
+
+export function SettingsDialog({
+  account,
+  memories,
+  labels,
+  aiConfigured,
+  batchConfigured,
+  triggerClassName,
+}: SettingsDialogProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            triggerClassName,
+            isOpen && "bg-sidebar-accent text-sidebar-foreground",
+          )}
+        >
+          <HugeiconsIcon
+            icon={Settings01Icon}
+            size={15}
+            strokeWidth={1.65}
+            className="shrink-0"
+          />
+          <span className="hidden truncate lg:block">Settings</span>
+        </button>
+      </DialogTrigger>
+      <DialogContent className="h-[min(760px,calc(100dvh-2rem))] max-w-[min(1040px,calc(100%-2rem))] grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden p-0 sm:max-w-[min(1040px,calc(100%-2rem))]">
+        <DialogHeader className="px-6 py-5 pr-14">
+          <DialogTitle className="text-lg font-semibold tracking-[-0.025em]">
+            Settings
+          </DialogTitle>
+          <DialogDescription>
+            Manage your account, Memory, labels, and billing in one place.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs
+          defaultValue="account"
+          orientation="vertical"
+          className="grid min-h-0 grid-cols-[64px_minmax(0,1fr)] gap-0 bg-background sm:grid-cols-[180px_minmax(0,1fr)]"
+        >
+          <TabsList
+            variant="line"
+            aria-label="Settings sections"
+            className="h-full w-full items-stretch justify-start gap-1 rounded-none bg-muted/35 p-3"
+          >
+            {settingsSections.map((section) => (
+              <TabsTrigger
+                key={section.value}
+                value={section.value}
+                className="h-10 w-full flex-none justify-start gap-2.5 px-3 text-[13px] after:inset-y-2 after:right-auto after:-left-3 after:h-auto after:w-0.5"
+                aria-label={section.label}
+              >
+                <HugeiconsIcon icon={section.icon} size={15} />
+                <span className="hidden sm:inline">{section.label}</span>
+              </TabsTrigger>
+            ))}
+          </TabsList>
+
+          <TabsContent value="account" className="min-h-0 overflow-y-auto">
+            <AccountSettings account={account} aiConfigured={aiConfigured} />
+          </TabsContent>
+          <TabsContent value="memory" className="min-h-0 overflow-y-auto">
+            <MemorySettings
+              memories={memories}
+              syncState={account.syncState.memory}
+              aiConfigured={aiConfigured}
+            />
+          </TabsContent>
+          <TabsContent value="labels" className="min-h-0 overflow-y-auto">
+            <LabelSettings labels={labels} batchConfigured={batchConfigured} />
+          </TabsContent>
+          <TabsContent value="billing" className="min-h-0 overflow-y-auto">
+            <BillingSettings />
+          </TabsContent>
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/settings/settings-dialog.tsx
+++ b/apps/web/src/components/settings/settings-dialog.tsx
@@ -31,6 +31,7 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
+import { useAccountSyncStore } from "@/stores/account-sync/store";
 
 import { LabelSettings } from "./label-settings";
 import { MemorySettings } from "./memory-settings";
@@ -107,9 +108,9 @@ function BillingSettings() {
         <span className="mx-auto grid size-10 place-items-center rounded-xl bg-secondary text-muted-foreground">
           <HugeiconsIcon icon={CreditCardIcon} size={18} />
         </span>
-        <p className="mt-4 text-sm font-semibold">No billing plan is configured</p>
+        <p className="mt-4 text-sm font-semibold">Billing details are unavailable</p>
         <p className="mx-auto mt-1.5 max-w-sm text-sm leading-6 text-muted-foreground">
-          This installation has no billing provider or paid plan attached.
+          This build does not expose a billing provider or plan status yet.
         </p>
       </div>
     </section>
@@ -134,6 +135,9 @@ export function SettingsDialog({
   triggerClassName,
 }: SettingsDialogProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const liveMemoryState = useAccountSyncStore(
+    (state) => state.progress?.memory,
+  );
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -193,7 +197,7 @@ export function SettingsDialog({
           <TabsContent value="memory" className="min-h-0 overflow-y-auto">
             <MemorySettings
               memories={memories}
-              syncState={account.syncState.memory}
+              syncState={liveMemoryState ?? account.syncState.memory}
               aiConfigured={aiConfigured}
             />
           </TabsContent>

--- a/apps/web/src/hooks/use-account-sync-events.ts
+++ b/apps/web/src/hooks/use-account-sync-events.ts
@@ -1,19 +1,29 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import type { AccountSyncStatusEvent } from "@invook/contracts";
+import { useEffect, useState } from "react";
 
-export function useAccountSyncEvents(): void {
-  const router = useRouter();
+import { parseAccountSyncStatusEvent } from "@/components/mail/account-pipeline-state";
+
+export function useAccountSyncEvents(
+  initialProgress: AccountSyncStatusEvent,
+): AccountSyncStatusEvent {
+  const [progress, setProgress] = useState(initialProgress);
 
   useEffect(() => {
     const eventSource = new EventSource("/v1/account-sync/events");
-    const refreshAccountSyncState = () => router.refresh();
-    eventSource.addEventListener("account-sync", refreshAccountSyncState);
+    const updateAccountSyncState = (event: Event) => {
+      if (!(event instanceof MessageEvent) || typeof event.data !== "string") return;
+      const nextProgress = parseAccountSyncStatusEvent(event.data);
+      if (nextProgress) setProgress(nextProgress);
+    };
+    eventSource.addEventListener("account-sync", updateAccountSyncState);
 
     return () => {
-      eventSource.removeEventListener("account-sync", refreshAccountSyncState);
+      eventSource.removeEventListener("account-sync", updateAccountSyncState);
       eventSource.close();
     };
-  }, [router]);
+  }, []);
+
+  return progress;
 }

--- a/apps/web/src/hooks/use-account-sync-events.ts
+++ b/apps/web/src/hooks/use-account-sync-events.ts
@@ -1,21 +1,35 @@
 "use client";
 
 import type { AccountSyncStatusEvent } from "@invook/contracts";
-import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 import { parseAccountSyncStatusEvent } from "@/components/mail/account-pipeline-state";
+import { useAccountSyncStore } from "@/stores/account-sync/store";
 
 export function useAccountSyncEvents(
   initialProgress: AccountSyncStatusEvent,
 ): AccountSyncStatusEvent {
-  const [progress, setProgress] = useState(initialProgress);
+  const router = useRouter();
+  const storedProgress = useAccountSyncStore((state) => state.progress);
+  const setProgress = useAccountSyncStore((state) => state.setProgress);
+  const reset = useAccountSyncStore((state) => state.reset);
 
   useEffect(() => {
+    if (!useAccountSyncStore.getState().progress) setProgress(initialProgress);
     const eventSource = new EventSource("/v1/account-sync/events");
     const updateAccountSyncState = (event: Event) => {
       if (!(event instanceof MessageEvent) || typeof event.data !== "string") return;
       const nextProgress = parseAccountSyncStatusEvent(event.data);
-      if (nextProgress) setProgress(nextProgress);
+      if (!nextProgress) return;
+      const previousProgress = useAccountSyncStore.getState().progress ?? initialProgress;
+      setProgress(nextProgress);
+      if (
+        previousProgress.memory !== "complete" &&
+        nextProgress.memory === "complete"
+      ) {
+        router.refresh();
+      }
     };
     eventSource.addEventListener("account-sync", updateAccountSyncState);
 
@@ -23,7 +37,9 @@ export function useAccountSyncEvents(
       eventSource.removeEventListener("account-sync", updateAccountSyncState);
       eventSource.close();
     };
-  }, []);
+  }, [initialProgress, router, setProgress]);
 
-  return progress;
+  useEffect(() => () => reset(), [reset]);
+
+  return storedProgress ?? initialProgress;
 }

--- a/apps/web/src/lib/event-stream-proxy.ts
+++ b/apps/web/src/lib/event-stream-proxy.ts
@@ -1,13 +1,13 @@
 import "server-only";
 
-import axios from "axios";
-import { Readable } from "node:stream";
+import axios, { type AxiosResponse } from "axios";
+import { PassThrough, Readable } from "node:stream";
 
 function getApiOrigin(): string {
   return (process.env.API_INTERNAL_URL ?? "http://127.0.0.1:4000").replace(/\/$/, "");
 }
 
-export async function proxyEventStream(request: Request, path: string) {
+export async function proxyEventStream(request: Request, path: string): Promise<Response> {
   const headers: Record<string, string> = {
     accept: "text/event-stream",
   };
@@ -16,12 +16,18 @@ export async function proxyEventStream(request: Request, path: string) {
   if (cookie) headers.cookie = cookie;
   if (lastEventId) headers["last-event-id"] = lastEventId;
 
-  const upstream = await axios.get(`${getApiOrigin()}${path}`, {
-    headers,
-    responseType: "stream",
-    signal: request.signal,
-    validateStatus: () => true,
-  });
+  let upstream: AxiosResponse<Readable>;
+  try {
+    upstream = await axios.get<Readable>(`${getApiOrigin()}${path}`, {
+      headers,
+      responseType: "stream",
+      signal: request.signal,
+      validateStatus: () => true,
+    });
+  } catch (error) {
+    if (axios.isCancel(error)) return new Response(null, { status: 204 });
+    throw error;
+  }
   const responseHeaders = new Headers();
   for (const name of [
     "cache-control",
@@ -34,7 +40,17 @@ export async function proxyEventStream(request: Request, path: string) {
     if (typeof value === "string") responseHeaders.set(name, value);
   }
 
-  const body = Readable.toWeb(upstream.data as Readable) as unknown as ReadableStream;
+  const responseBody = new PassThrough();
+  upstream.data.once("error", (error: unknown) => {
+    if (axios.isCancel(error)) {
+      responseBody.end();
+      return;
+    }
+    responseBody.destroy(new Error("Upstream event stream failed"));
+  });
+  upstream.data.pipe(responseBody);
+
+  const body = Readable.toWeb(responseBody) as unknown as ReadableStream;
   return new Response(body, {
     headers: responseHeaders,
     status: upstream.status,

--- a/apps/web/src/stores/account-sync/store.ts
+++ b/apps/web/src/stores/account-sync/store.ts
@@ -1,0 +1,24 @@
+import type { AccountSyncStatusEvent } from "@invook/contracts";
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+interface AccountSyncStoreState {
+  progress: AccountSyncStatusEvent | null;
+  setProgress: (progress: AccountSyncStatusEvent) => void;
+  reset: () => void;
+}
+
+const initialState: Pick<AccountSyncStoreState, "progress"> = {
+  progress: null,
+};
+
+export const useAccountSyncStore = create<AccountSyncStoreState>()(
+  devtools(
+    (set) => ({
+      ...initialState,
+      setProgress: (progress) => set({ progress }),
+      reset: () => set(initialState),
+    }),
+    { name: "account-sync-store" },
+  ),
+);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -28,6 +28,7 @@ export type MailSyncProgress = {
 export type AccountSyncStatusEvent = {
   mailSync: MailSyncProgress;
   indexing: IndexingProgress;
+  memory: AccountSyncStage;
 };
 
 export const mailboxViews = [

--- a/packages/database/src/mail-sync-progress.test.ts
+++ b/packages/database/src/mail-sync-progress.test.ts
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import {
   deriveMailSyncProgress,
-  hasMailSyncPercentageAdvanced,
+  hasMailSyncProgressAdvanced,
 } from "./mail-sync-progress";
 
 test("mail sync progress preserves durable run counts", () => {
@@ -37,9 +37,9 @@ test("a completed account is known to have finished discovery without a run", ()
   });
 });
 
-test("sync notifications advance only on a new whole percentage", () => {
+test("sync notifications advance on a new percentage or durable count interval", () => {
   assert.equal(
-    hasMailSyncPercentageAdvanced({
+    hasMailSyncProgressAdvanced({
       discoveryComplete: true,
       discoveredMessageCount: 10_000,
       previousProcessedMessageCount: 99,
@@ -48,16 +48,25 @@ test("sync notifications advance only on a new whole percentage", () => {
     true,
   );
   assert.equal(
-    hasMailSyncPercentageAdvanced({
+    hasMailSyncProgressAdvanced({
       discoveryComplete: true,
       discoveredMessageCount: 10_000,
-      previousProcessedMessageCount: 100,
-      processedMessageCount: 101,
+      previousProcessedMessageCount: 199,
+      processedMessageCount: 200,
+    }),
+    true,
+  );
+  assert.equal(
+    hasMailSyncProgressAdvanced({
+      discoveryComplete: true,
+      discoveredMessageCount: 10_000,
+      previousProcessedMessageCount: 200,
+      processedMessageCount: 201,
     }),
     false,
   );
   assert.equal(
-    hasMailSyncPercentageAdvanced({
+    hasMailSyncProgressAdvanced({
       discoveryComplete: false,
       discoveredMessageCount: 10_000,
       previousProcessedMessageCount: 99,

--- a/packages/database/src/mail-sync-progress.ts
+++ b/packages/database/src/mail-sync-progress.ts
@@ -21,7 +21,9 @@ export function deriveMailSyncProgress(input: {
   };
 }
 
-export function hasMailSyncPercentageAdvanced(input: {
+const MAIL_SYNC_NOTIFICATION_INTERVAL = 100;
+
+export function hasMailSyncProgressAdvanced(input: {
   discoveryComplete: boolean;
   discoveredMessageCount: number;
   previousProcessedMessageCount: number;
@@ -35,5 +37,11 @@ export function hasMailSyncPercentageAdvanced(input: {
   const percentage = Math.floor(
     (input.processedMessageCount / input.discoveredMessageCount) * 100,
   );
-  return percentage > previousPercentage;
+  const previousInterval = Math.floor(
+    input.previousProcessedMessageCount / MAIL_SYNC_NOTIFICATION_INTERVAL,
+  );
+  const interval = Math.floor(
+    input.processedMessageCount / MAIL_SYNC_NOTIFICATION_INTERVAL,
+  );
+  return percentage > previousPercentage || interval > previousInterval;
 }

--- a/packages/database/src/repositories.ts
+++ b/packages/database/src/repositories.ts
@@ -1130,22 +1130,116 @@ export async function getMailboxWorkspace(
       )
     : undefined;
 
-  const rawMailboxThreads = await database
-    .select({
-      id: threads.id,
-      subject: threads.subject,
-      snippet: threads.snippet,
-      participants: threads.participants,
-      latestMessageAt: threads.latestMessageAt,
-      messageCount: threads.messageCount,
-    })
-    .from(threads)
-    .where(and(mailboxScope, cursorCondition))
-    .orderBy(
-      cursor?.direction === "newer" ? asc(mailboxSortTime) : desc(mailboxSortTime),
-      cursor?.direction === "newer" ? asc(threads.id) : desc(threads.id),
-    )
-    .limit(mailboxPageSize + 1);
+  const selectedThreadPromise = selectedThreadId
+    ? database
+        .select({
+          id: threads.id,
+          providerThreadId: threads.providerThreadId,
+          subject: threads.subject,
+          participants: threads.participants,
+          latestMessageAt: threads.latestMessageAt,
+          messageCount: threads.messageCount,
+        })
+        .from(threads)
+        .where(
+          and(
+            eq(threads.id, selectedThreadId),
+            eq(threads.userId, userId),
+            eq(threads.accountId, account.id),
+          ),
+        )
+        .limit(1)
+    : Promise.resolve([]);
+  const [
+    rawMailboxThreads,
+    [threadCount],
+    memoryRows,
+    mailLabelRows,
+    [threadCountRow],
+    analyzedCounts,
+    selectedThreadRows,
+  ] = await Promise.all([
+    database
+      .select({
+        id: threads.id,
+        subject: threads.subject,
+        snippet: threads.snippet,
+        participants: threads.participants,
+        latestMessageAt: threads.latestMessageAt,
+        messageCount: threads.messageCount,
+      })
+      .from(threads)
+      .where(and(mailboxScope, cursorCondition))
+      .orderBy(
+        cursor?.direction === "newer" ? asc(mailboxSortTime) : desc(mailboxSortTime),
+        cursor?.direction === "newer" ? asc(threads.id) : desc(threads.id),
+      )
+      .limit(mailboxPageSize + 1),
+    database
+      .select({ value: count(threads.id) })
+      .from(threads)
+      .where(mailboxScope),
+    database
+      .select({
+        id: memoryEntries.id,
+        type: memoryEntries.memoryType,
+        contactEmail: memoryEntries.contactEmail,
+        statement: memoryEntries.statement,
+        source: memoryEntries.source,
+        confidence: memoryEntries.confidence,
+        evidenceMessageIds: memoryEntries.evidenceMessageIds,
+        evidenceDraftIds: memoryEntries.evidenceDraftIds,
+        createdAt: memoryEntries.createdAt,
+        updatedAt: memoryEntries.updatedAt,
+      })
+      .from(memoryEntries)
+      .where(
+        and(eq(memoryEntries.userId, userId), eq(memoryEntries.accountId, account.id)),
+      )
+      .orderBy(
+        asc(memoryEntries.memoryType),
+        asc(memoryEntries.contactEmail),
+        asc(memoryEntries.createdAt),
+      ),
+    database
+      .select({
+        id: mailLabels.id,
+        name: mailLabels.name,
+        description: mailLabels.description,
+        systemKey: mailLabels.systemKey,
+        definitionVersion: mailLabels.definitionVersion,
+        analysisState: mailLabels.analysisState,
+        createdAt: mailLabels.createdAt,
+      })
+      .from(mailLabels)
+      .where(
+        and(eq(mailLabels.userId, userId), eq(mailLabels.accountId, account.id)),
+      )
+      .orderBy(asc(mailLabels.createdAt), asc(mailLabels.name)),
+    database
+      .select({ value: count(threads.id) })
+      .from(threads)
+      .where(and(eq(threads.userId, userId), eq(threads.accountId, account.id))),
+    database
+      .select({
+        labelId: threadLabelAnalyses.labelId,
+        definitionVersion: threadLabelAnalyses.definitionVersion,
+        value: count(threadLabelAnalyses.id),
+      })
+      .from(threadLabelAnalyses)
+      .where(
+        and(
+          eq(threadLabelAnalyses.userId, userId),
+          eq(threadLabelAnalyses.accountId, account.id),
+        ),
+      )
+      .groupBy(
+        threadLabelAnalyses.labelId,
+        threadLabelAnalyses.definitionVersion,
+      ),
+    selectedThreadPromise,
+  ]);
+  const [selectedThread] = selectedThreadRows;
   const hasExtraPage = rawMailboxThreads.length > mailboxPageSize;
   const currentPage = rawMailboxThreads.slice(0, mailboxPageSize);
   const mailboxThreads =
@@ -1153,10 +1247,6 @@ export async function getMailboxWorkspace(
   const hasNewerPage = Boolean(cursor) &&
     (cursor?.direction === "older" || hasExtraPage);
   const hasOlderPage = cursor?.direction === "newer" ? true : hasExtraPage;
-  const [threadCount] = await database
-    .select({ value: count(threads.id) })
-    .from(threads)
-    .where(mailboxScope);
   const firstMailboxThread = mailboxThreads[0];
   const lastMailboxThread = mailboxThreads.at(-1);
   const pagination = {
@@ -1171,66 +1261,6 @@ export async function getMailboxWorkspace(
     totalThreadCount: threadCount?.value ?? 0,
   };
 
-  const memoryRows = await database
-    .select({
-      id: memoryEntries.id,
-      type: memoryEntries.memoryType,
-      contactEmail: memoryEntries.contactEmail,
-      statement: memoryEntries.statement,
-      source: memoryEntries.source,
-      confidence: memoryEntries.confidence,
-      evidenceMessageIds: memoryEntries.evidenceMessageIds,
-      evidenceDraftIds: memoryEntries.evidenceDraftIds,
-      createdAt: memoryEntries.createdAt,
-      updatedAt: memoryEntries.updatedAt,
-    })
-    .from(memoryEntries)
-    .where(
-      and(eq(memoryEntries.userId, userId), eq(memoryEntries.accountId, account.id)),
-    )
-    .orderBy(
-      asc(memoryEntries.memoryType),
-      asc(memoryEntries.contactEmail),
-      asc(memoryEntries.createdAt),
-    );
-
-  const mailLabelRows = await database
-    .select({
-      id: mailLabels.id,
-      name: mailLabels.name,
-      description: mailLabels.description,
-      systemKey: mailLabels.systemKey,
-      definitionVersion: mailLabels.definitionVersion,
-      analysisState: mailLabels.analysisState,
-      createdAt: mailLabels.createdAt,
-    })
-    .from(mailLabels)
-    .where(
-      and(eq(mailLabels.userId, userId), eq(mailLabels.accountId, account.id)),
-    )
-    .orderBy(asc(mailLabels.createdAt), asc(mailLabels.name));
-
-  const [threadCountRow] = await database
-    .select({ value: count(threads.id) })
-    .from(threads)
-    .where(and(eq(threads.userId, userId), eq(threads.accountId, account.id)));
-  const analyzedCounts = await database
-    .select({
-      labelId: threadLabelAnalyses.labelId,
-      definitionVersion: threadLabelAnalyses.definitionVersion,
-      value: count(threadLabelAnalyses.id),
-    })
-    .from(threadLabelAnalyses)
-    .where(
-      and(
-        eq(threadLabelAnalyses.userId, userId),
-        eq(threadLabelAnalyses.accountId, account.id),
-      ),
-    )
-    .groupBy(
-      threadLabelAnalyses.labelId,
-      threadLabelAnalyses.definitionVersion,
-    );
   const analyzedCountByLabel = new Map(
     analyzedCounts.map((entry) => [
       `${entry.labelId}:${entry.definitionVersion}`,
@@ -1264,36 +1294,15 @@ export async function getMailboxWorkspace(
       return left.name.localeCompare(right.name);
     });
 
-  const [selectedThread] = selectedThreadId
-    ? await database
-        .select({
-          id: threads.id,
-          providerThreadId: threads.providerThreadId,
-          subject: threads.subject,
-          participants: threads.participants,
-          latestMessageAt: threads.latestMessageAt,
-          messageCount: threads.messageCount,
-        })
-        .from(threads)
-        .where(
-          and(
-            eq(threads.id, selectedThreadId),
-            eq(threads.userId, userId),
-            eq(threads.accountId, account.id),
-          ),
-        )
-        .limit(1)
-    : [];
-
   const threadIds = Array.from(
     new Set([
       ...mailboxThreads.map((thread) => thread.id),
       ...(selectedThread ? [selectedThread.id] : []),
     ]),
   );
-  const appliedLabelRows =
-    threadIds.length > 0
-      ? await database
+  const [appliedLabelRows, gmailLabelRows] = threadIds.length > 0
+    ? await Promise.all([
+        database
           .select({
             threadId: threadLabels.threadId,
             labelId: threadLabels.labelId,
@@ -1309,11 +1318,8 @@ export async function getMailboxWorkspace(
               inArray(threadLabels.threadId, threadIds),
               eq(threadLabels.state, "applied"),
             ),
-          )
-      : [];
-  const gmailLabelRows =
-    threadIds.length > 0
-      ? await database
+          ),
+        database
           .select({
             threadId: messages.threadId,
             id: gmailLabels.id,
@@ -1328,8 +1334,9 @@ export async function getMailboxWorkspace(
             eq(gmailMessageLabels.messageId, messages.id),
           )
           .innerJoin(gmailLabels, eq(gmailLabels.id, gmailMessageLabels.gmailLabelId))
-          .where(inArray(messages.threadId, threadIds))
-      : [];
+          .where(inArray(messages.threadId, threadIds)),
+      ])
+    : [[], []];
   const labelsByThread = new Map<string, typeof appliedLabelRows>();
   for (const label of appliedLabelRows) {
     const current = labelsByThread.get(label.threadId) ?? [];
@@ -1385,32 +1392,72 @@ export async function getMailboxWorkspace(
     };
   }
 
-  const threadMessages = await database
-    .select({
-      id: messages.id,
-      providerMessageId: messages.providerMessageId,
-      providerHistoryId: messages.providerHistoryId,
-      internalDate: messages.internalDate,
-      sizeEstimate: messages.sizeEstimate,
-      headerLines: messages.headerLines,
-      direction: messages.direction,
-      sender: messages.sender,
-      recipients: messages.recipients,
-      subject: messages.subject,
-      bodyText: messages.bodyText,
-      bodyHtml: messages.bodyHtml,
-      rawChecksumSha256: messages.rawChecksumSha256,
-      rawContentLength: messages.rawContentLength,
-      sentAt: messages.sentAt,
-    })
-    .from(messages)
-    .where(and(eq(messages.userId, userId), eq(messages.threadId, selectedThread.id)))
-    .orderBy(asc(messages.sentAt));
+  const [threadMessages, [threadDraft], providerDrafts] = await Promise.all([
+    database
+      .select({
+        id: messages.id,
+        providerMessageId: messages.providerMessageId,
+        providerHistoryId: messages.providerHistoryId,
+        internalDate: messages.internalDate,
+        sizeEstimate: messages.sizeEstimate,
+        headerLines: messages.headerLines,
+        direction: messages.direction,
+        sender: messages.sender,
+        recipients: messages.recipients,
+        subject: messages.subject,
+        bodyText: messages.bodyText,
+        bodyHtml: messages.bodyHtml,
+        rawChecksumSha256: messages.rawChecksumSha256,
+        rawContentLength: messages.rawContentLength,
+        sentAt: messages.sentAt,
+      })
+      .from(messages)
+      .where(and(eq(messages.userId, userId), eq(messages.threadId, selectedThread.id)))
+      .orderBy(asc(messages.sentAt)),
+    database
+      .select({
+        id: drafts.id,
+        threadId: drafts.threadId,
+        status: drafts.status,
+        generatedText: drafts.generatedText,
+        currentText: drafts.currentText,
+        usedMemoryIds: drafts.usedMemoryIds,
+        updatedAt: drafts.updatedAt,
+      })
+      .from(drafts)
+      .where(
+        and(
+          eq(drafts.userId, userId),
+          eq(drafts.threadId, selectedThread.id),
+          eq(drafts.status, "editing"),
+          isNotNull(drafts.generatedText),
+        ),
+      )
+      .orderBy(desc(drafts.updatedAt))
+      .limit(1),
+    database
+      .select({
+        id: gmailDrafts.id,
+        providerDraftId: gmailDrafts.providerDraftId,
+        providerMessageId: gmailDrafts.providerMessageId,
+        providerThreadId: gmailDrafts.providerThreadId,
+        updatedAt: gmailDrafts.updatedAt,
+      })
+      .from(gmailDrafts)
+      .where(
+        and(
+          eq(gmailDrafts.accountId, account.id),
+          eq(gmailDrafts.providerThreadId, selectedThread.providerThreadId),
+          isNotNull(gmailDrafts.providerMessageId),
+        ),
+      )
+      .orderBy(desc(gmailDrafts.updatedAt)),
+  ]);
 
   const messageIds = threadMessages.map((message) => message.id);
-  const attachmentRows =
-    messageIds.length > 0
-      ? await database
+  const [attachmentRows, messageGmailLabelRows] = messageIds.length > 0
+    ? await Promise.all([
+        database
           .select({
             id: messageAttachments.id,
             messageId: messageAttachments.messageId,
@@ -1425,18 +1472,8 @@ export async function getMailboxWorkspace(
           })
           .from(messageAttachments)
           .where(inArray(messageAttachments.messageId, messageIds))
-          .orderBy(asc(messageAttachments.filename))
-      : [];
-  const attachmentsByMessage = new Map<string, typeof attachmentRows>();
-  for (const attachment of attachmentRows) {
-    const current = attachmentsByMessage.get(attachment.messageId) ?? [];
-    current.push(attachment);
-    attachmentsByMessage.set(attachment.messageId, current);
-  }
-
-  const messageGmailLabelRows =
-    messageIds.length > 0
-      ? await database
+          .orderBy(asc(messageAttachments.filename)),
+        database
           .select({
             messageId: gmailMessageLabels.messageId,
             id: gmailLabels.id,
@@ -1447,54 +1484,22 @@ export async function getMailboxWorkspace(
           })
           .from(gmailMessageLabels)
           .innerJoin(gmailLabels, eq(gmailLabels.id, gmailMessageLabels.gmailLabelId))
-          .where(inArray(gmailMessageLabels.messageId, messageIds))
-      : [];
+          .where(inArray(gmailMessageLabels.messageId, messageIds)),
+      ])
+    : [[], []];
+  const attachmentsByMessage = new Map<string, typeof attachmentRows>();
+  for (const attachment of attachmentRows) {
+    const current = attachmentsByMessage.get(attachment.messageId) ?? [];
+    current.push(attachment);
+    attachmentsByMessage.set(attachment.messageId, current);
+  }
+
   const gmailLabelsByMessage = new Map<string, typeof messageGmailLabelRows>();
   for (const label of messageGmailLabelRows) {
     const current = gmailLabelsByMessage.get(label.messageId) ?? [];
     current.push(label);
     gmailLabelsByMessage.set(label.messageId, current);
   }
-
-  const [threadDraft] = await database
-    .select({
-      id: drafts.id,
-      threadId: drafts.threadId,
-      status: drafts.status,
-      generatedText: drafts.generatedText,
-      currentText: drafts.currentText,
-      usedMemoryIds: drafts.usedMemoryIds,
-      updatedAt: drafts.updatedAt,
-    })
-    .from(drafts)
-    .where(
-      and(
-        eq(drafts.userId, userId),
-        eq(drafts.threadId, selectedThread.id),
-        eq(drafts.status, "editing"),
-        isNotNull(drafts.generatedText),
-      ),
-    )
-    .orderBy(desc(drafts.updatedAt))
-    .limit(1);
-
-  const providerDrafts = await database
-    .select({
-      id: gmailDrafts.id,
-      providerDraftId: gmailDrafts.providerDraftId,
-      providerMessageId: gmailDrafts.providerMessageId,
-      providerThreadId: gmailDrafts.providerThreadId,
-      updatedAt: gmailDrafts.updatedAt,
-    })
-    .from(gmailDrafts)
-    .where(
-      and(
-        eq(gmailDrafts.accountId, account.id),
-        eq(gmailDrafts.providerThreadId, selectedThread.providerThreadId),
-        isNotNull(gmailDrafts.providerMessageId),
-      ),
-    )
-    .orderBy(desc(gmailDrafts.updatedAt));
 
   return {
     account,
@@ -1591,6 +1596,19 @@ export async function getMailSyncProgressForAccount(
     state: account.syncState.mailSync,
     run: run ?? null,
   });
+}
+
+export async function getAccountSyncStateForAccount(
+  input: { accountId: string },
+  database: Database = getDatabase(),
+): Promise<AccountSyncState | null> {
+  const [account] = await database
+    .select({ syncState: connectedAccounts.syncState })
+    .from(connectedAccounts)
+    .where(eq(connectedAccounts.id, input.accountId))
+    .limit(1);
+
+  return account?.syncState ?? null;
 }
 
 async function getIndexingProgressWithExecutor(
@@ -3397,13 +3415,18 @@ export async function setMemorySyncStage(
   stage: AccountSyncState["memory"],
   database: Database = getDatabase(),
 ) {
-  await database
-    .update(connectedAccounts)
-    .set({
-      syncState: sql`jsonb_set(${connectedAccounts.syncState}, '{memory}', to_jsonb(${stage}::text), true)`,
-      updatedAt: new Date(),
-    })
-    .where(eq(connectedAccounts.id, accountId));
+  await database.transaction(async (transaction) => {
+    await transaction
+      .update(connectedAccounts)
+      .set({
+        syncState: sql`jsonb_set(${connectedAccounts.syncState}, '{memory}', to_jsonb(${stage}::text), true)`,
+        updatedAt: new Date(),
+      })
+      .where(eq(connectedAccounts.id, accountId));
+    await transaction.execute(
+      sql`select pg_notify('invook_account_sync', ${JSON.stringify({ accountId })})`,
+    );
+  });
 }
 
 export async function setIndexingSyncStage(

--- a/packages/database/src/workflows.ts
+++ b/packages/database/src/workflows.ts
@@ -30,7 +30,7 @@ import {
   workflowSteps,
 } from "./schema";
 import { createGmailWatchRecoveryStep } from "./gmail-watch-schedule";
-import { hasMailSyncPercentageAdvanced } from "./mail-sync-progress";
+import { hasMailSyncProgressAdvanced } from "./mail-sync-progress";
 import type {
   QueueName,
   WorkflowStepInput,
@@ -1185,7 +1185,7 @@ async function enqueueFinalizeIfReady(runId: string, database: Database) {
     })
     .where(eq(mailSyncRuns.id, runId));
   if (
-    hasMailSyncPercentageAdvanced({
+    hasMailSyncProgressAdvanced({
       discoveryComplete: run.discoveryComplete,
       discoveredMessageCount: counts.total,
       previousProcessedMessageCount: run.processedMessageCount,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       uuid:
         specifier: ^14.0.1
         version: 14.0.1
+      zustand:
+        specifier: ^5.0.15
+        version: 5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.1.18
@@ -5022,6 +5025,24 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zustand@5.0.15:
+    resolution: {integrity: sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@ai-sdk/gateway@4.0.46(zod@4.4.3)':
@@ -9854,3 +9875,9 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.4.3: {}
+
+  zustand@5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)):
+    optionalDependencies:
+      '@types/react': 19.2.18
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)


### PR DESCRIPTION
## Summary
- open Settings as an in-place dialog with Account, Memory, Labels, and Billing sections
- consolidate Gmail sync, indexing, and Memory into one direct-SSE sidebar pipeline status and remove the duplicate agent banner
- reduce mailbox navigation latency by parallelizing independent workspace reads and add route-pending feedback
- suppress sensitive Axios metadata when SSE clients disconnect

## Verification
- make verify
- docker compose config --quiet
- rebuilt the local API/web runtime image; services are healthy
- runtime logs checked for cancellation errors and credential-bearing request dumps

## Browser note
Automated post-rebuild click-through was blocked by the in-app browser URL policy. The app is running at http://localhost:3000 for manual UI verification.