### PR TITLE
Add open source governance files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported privately to the community leaders at <hello@thinkingsoundlab.com>.
+reported privately to the community leaders at <abhishek@thinkingsoundlab.com>.
 Use the subject line `[Invook conduct report]` and do not open a public issue.
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported privately to the community leaders at <hello@thinkingsoundlab.com>.
+Use the subject line `[Invook conduct report]` and do not open a public issue.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant][contributor-covenant], version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][version-2-1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla-code-of-conduct].
+
+For answers to common questions about this Code of Conduct, see the
+[Contributor Covenant FAQ][faq]. Translations are available from the
+[Contributor Covenant translations page][translations].
+
+[contributor-covenant]: https://www.contributor-covenant.org
+[version-2-1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla-code-of-conduct]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,10 +28,16 @@ git checkout -b fix/short-description
 corepack enable
 pnpm install --frozen-lockfile
 cp .env.example .env.local
+openssl rand -base64 32
+openssl rand -base64 32
 ```
 
-Fill only the local environment values you need. Never commit `.env.local` or
-real secrets. Start the complete local stack with:
+Put the two different generated values in `BETTER_AUTH_SECRET` and
+`TOKEN_ENCRYPTION_KEY`, respectively. Fill every other blank value required by
+the services you intend to run; authentication requires the Better Auth Google
+client values, while a complete Gmail connection also requires the Gmail OAuth
+and Pub/Sub values documented in the README. Never commit `.env.local` or real
+credentials. Start the complete local stack with:
 
 ```bash
 make dev

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contributing to Invook
+
+Thank you for helping improve Invook. Contributions can include bug fixes,
+documentation, tests, design improvements, and focused product changes.
+Participation in the project is governed by our
+[Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Before You Start
+
+- Search [existing issues](https://github.com/Thinking-Sound-Lab/Invook-Email-/issues)
+  before opening a new one.
+- Open an issue before investing in a large feature or architecture change so
+  its scope and ownership can be agreed first.
+- Follow the [Security Policy](./SECURITY.md) instead of opening a public issue
+  for a suspected vulnerability.
+- Never include credentials, tokens, real mailbox content, raw MIME, attachment
+  bytes, or private provider payloads in an issue, pull request, test, or log.
+
+## Development Setup
+
+Invook is a pnpm workspace that requires Node.js 22+, pnpm 11+, and Docker
+Desktop. Fork the repository, clone your fork, and create a focused branch:
+
+```bash
+git clone https://github.com/<your-username>/Invook-Email-.git
+cd Invook-Email-
+git checkout -b fix/short-description
+corepack enable
+pnpm install --frozen-lockfile
+cp .env.example .env.local
+```
+
+Fill only the local environment values you need. Never commit `.env.local` or
+real secrets. Start the complete local stack with:
+
+```bash
+make dev
+```
+
+See the [README](../README.md) for Google OAuth, Gmail, Pub/Sub, model, and
+object-storage configuration. If an external integration is not configured,
+preserve an honest unavailable state rather than adding fake data.
+
+## Repository Boundaries
+
+- `apps/web` owns the Next.js user interface and same-origin proxies.
+- `apps/api` owns Fastify HTTP admission, authentication, authorization,
+  validation, webhooks, SSE, and response serialization.
+- `apps/worker` owns retryable and long-running durable work.
+- `packages/*` owns reusable domain and infrastructure code.
+- PostgreSQL workflow and outbox records are the durable source of work;
+  queues and notifications execute or wake that work.
+
+Read the root `AGENTS.md` and the closest directory-specific `AGENTS.md` before
+editing. Keep application-to-package dependencies one-way, use public
+`@invook/*` package exports across workspaces, and do not import server-only
+packages into `apps/web`.
+
+## Making a Change
+
+1. Keep the change small and focused on one problem.
+2. Add or update tests for changed behavior and failure modes.
+3. Update every producer and consumer when changing a shared contract.
+4. Generate and inspect a migration for schema changes.
+5. Update documentation and configuration when behavior or setup changes.
+6. Remove the superseded path and search for obsolete symbols before handoff.
+
+Use pnpm for all repository commands. Application HTTP uses Fastify and Axios;
+UUID generation uses the `uuid` package. Follow the existing TypeScript,
+naming, privacy, durability, and retry-safety rules in `AGENTS.md`.
+
+## Verification
+
+Run the narrowest relevant checks while iterating. Before opening a pull
+request, run the full repository gate and validate Docker Compose:
+
+```bash
+make verify
+docker compose -f docker/compose.yml config --quiet
+```
+
+If an external service prevents a check, state exactly what ran, what failed,
+and what remains unverified. Do not weaken assertions or claim checks that were
+not performed.
+
+## Pull Requests
+
+A pull request should:
+
+- explain the problem, the invariant being changed, and the chosen solution;
+- link related issues with `Fixes #123` or `Refs #123` when applicable;
+- identify security, privacy, migration, concurrency, or compatibility risks;
+- include screenshots for visible UI changes;
+- list the exact verification commands and results; and
+- remain free of unrelated formatting or refactoring changes.
+
+Use clear, imperative commit subjects. Maintainers may ask for changes to keep
+contracts, data ownership, and repository boundaries consistent.
+
+## License
+
+Invook is licensed under the [Apache License 2.0](../LICENSE). Unless you
+explicitly state otherwise, contributions intentionally submitted for inclusion
+in Invook are provided under the same license, as described in Section 5 of the
+license.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+Invook processes private mailbox data and provider credentials. Please report
+suspected vulnerabilities privately so maintainers can investigate before
+details are disclosed publicly.
+
+## Supported Versions
+
+Invook has not published a stable release. Security fixes are applied to the
+latest commit on the `main` branch. Older commits and unmaintained branches are
+not supported.
+
+## Reporting a Vulnerability
+
+Email <hello@thinkingsoundlab.com> with the subject
+`[Invook security] <short description>`. Do not open a public GitHub issue,
+discussion, or pull request for an undisclosed vulnerability.
+
+Include, when available:
+
+- the affected component, route, or commit;
+- a clear description and potential impact;
+- minimal steps or a proof of concept that reproduces the issue;
+- required configuration and whether the issue is remotely exploitable;
+- suggested mitigations; and
+- how you would like to be credited, or whether you prefer anonymity.
+
+Use synthetic data and redact all credentials, access tokens, email content,
+raw MIME, attachments, and provider payloads. If sensitive evidence is required,
+ask the maintainers to agree on a safe transfer method before sending it.
+
+Maintainers will acknowledge the report as soon as practical, validate its
+scope, and coordinate remediation and disclosure with the reporter. A report
+may be declined when it cannot be reproduced, affects only an unsupported
+version, or concerns a third-party service outside Invook's control; in that
+case, the maintainers will explain the decision when possible.
+
+## Disclosure
+
+Please allow maintainers reasonable time to investigate and release a fix
+before public disclosure. Once remediation is available, maintainers may publish
+a GitHub Security Advisory describing the impact, affected versions, fix, and
+reporter credit.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -12,7 +12,7 @@ not supported.
 
 ## Reporting a Vulnerability
 
-Email <hello@thinkingsoundlab.com> with the subject
+Email <abhishek@thinkingsoundlab.com> with the subject
 `[Invook security] <short description>`. Do not open a public GitHub issue,
 discussion, or pull request for an undisclosed vulnerability.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Thinking Sound Lab
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Invook
+Copyright 2026 Thinking Sound Lab
+
+This product includes software developed for the Invook project.

--- a/README.md
+++ b/README.md
@@ -184,4 +184,11 @@ docker compose -f docker/compose.yml config --quiet
 - [Product requirements](./docs/product-requirements.md)
 - [Gmail mailbox replica contract](./docs/gmail-replica-contract.md)
 
-The project license has not been selected yet. Do not assume reuse rights until a license is added.
+## Community and License
+
+- [Contributing guide](./.github/CONTRIBUTING.md)
+- [Code of Conduct](./.github/CODE_OF_CONDUCT.md)
+- [Security Policy](./.github/SECURITY.md)
+
+Invook is licensed under the [Apache License 2.0](./LICENSE). See
+[NOTICE](./NOTICE) for attribution information.

--- a/docs/product-requirements.md
+++ b/docs/product-requirements.md
@@ -299,5 +299,4 @@ The Memory-first slice is successful when:
 After the Memory loop is measured with real use:
 
 1. evaluate broader factual retrieval independently of Memory extraction;
-2. add sending, scheduling, reminders, and safe automations;
-3. choose an open-source license and add contribution governance.
+2. add sending, scheduling, reminders, and safe automations.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "invook",
   "version": "0.2.0",
   "private": true,
+  "license": "Apache-2.0",
   "packageManager": "pnpm@11.10.0",
   "description": "An open-source, AI-native Gmail client that drafts with learned Memory.",
   "scripts": {


### PR DESCRIPTION
## Summary

- license Invook under Apache License 2.0 and add attribution notice
- add tailored contribution, security, and Contributor Covenant policies
- link governance documents from the README and update repository metadata
- remove the completed licensing-governance roadmap item

## Verification

- `make verify`
- `docker compose -f docker/compose.yml config --quiet`
- local and external governance link checks
- `git diff --check`