### PR TITLE
Merge sidebar labels across connected accounts

### DIFF
--- a/apps/web/src/components/mail/mail-account-scope.ts
+++ b/apps/web/src/components/mail/mail-account-scope.ts
@@ -1,6 +1,6 @@
 import type {
-  InvookLabel,
   MailboxAccount,
+  MailboxAccountLabel,
   MailboxScopeSidebarCounts,
   MailboxShell,
   MailboxSidebarCounts,
@@ -34,7 +34,7 @@ export function selectedMailboxAccount(
 export function accountLabels(
   shell: Pick<MailboxShell, "accountLabels">,
   accountId: string,
-): InvookLabel[] {
+): MailboxAccountLabel[] {
   return (
     shell.accountLabels.find((entry) => entry.accountId === accountId)?.labels ?? []
   );

--- a/apps/web/src/components/mail/mail-sidebar-labels.test.ts
+++ b/apps/web/src/components/mail/mail-sidebar-labels.test.ts
@@ -1,11 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import type { InvookLabel } from "@invook/contracts";
+import type { MailboxAccountLabel } from "@invook/contracts";
 
 import { listSidebarLabels } from "./mail-sidebar-labels";
 
-function label(overrides: Partial<InvookLabel> & Pick<InvookLabel, "id" | "name">): InvookLabel {
+function label(
+  overrides: Partial<MailboxAccountLabel> &
+    Pick<MailboxAccountLabel, "id" | "name" | "normalizedName">,
+): MailboxAccountLabel {
   return {
     description: "Requires a reply",
     systemKey: null,
@@ -17,10 +20,15 @@ function label(overrides: Partial<InvookLabel> & Pick<InvookLabel, "id" | "name"
 
 test("sidebar labels contain only sorted Invook label definitions", () => {
   const labels = listSidebarLabels([
-    label({ id: "custom-label", name: "Action needed" }),
+    label({
+      id: "custom-label",
+      name: "Action needed",
+      normalizedName: "action needed",
+    }),
     label({
       id: "newsletter-label",
       name: "Newsletter",
+      normalizedName: "newsletter",
       description: "Recurring editorial mail",
       systemKey: "newsletter",
     }),
@@ -36,12 +44,31 @@ test("sidebar labels contain only sorted Invook label definitions", () => {
   ]);
 });
 
-test("sidebar labels merge account labels that share one name", () => {
+test("sidebar labels merge account labels that share a stored identity", () => {
   const labels = listSidebarLabels([
-    label({ id: "first-billing", name: "Billing", systemKey: "billing" }),
-    label({ id: "first-important", name: "Important", systemKey: "important" }),
-    label({ id: "second-billing", name: "billing", systemKey: "billing" }),
-    label({ id: "second-receipts", name: "Receipts" }),
+    label({
+      id: "first-billing",
+      name: "Billing",
+      normalizedName: "billing",
+      systemKey: "billing",
+    }),
+    label({
+      id: "first-important",
+      name: "Important",
+      normalizedName: "important",
+      systemKey: "important",
+    }),
+    label({
+      id: "second-billing",
+      name: "billing",
+      normalizedName: "billing",
+      systemKey: "billing",
+    }),
+    label({
+      id: "second-receipts",
+      name: "Receipts",
+      normalizedName: "receipts",
+    }),
   ]);
 
   assert.deepEqual(labels, [
@@ -52,4 +79,16 @@ test("sidebar labels merge account labels that share one name", () => {
     },
     { id: "second-receipts", name: "Receipts", labelIds: ["second-receipts"] },
   ]);
+});
+
+test("a label stored under a different identity stays a separate entry", () => {
+  const labels = listSidebarLabels([
+    label({ id: "stored-invariant", name: "Irmak", normalizedName: "irmak" }),
+    label({ id: "stored-locale", name: "Irmak", normalizedName: "ırmak" }),
+  ]);
+
+  assert.deepEqual(
+    labels.map((entry) => entry.labelIds),
+    [["stored-invariant"], ["stored-locale"]],
+  );
 });

--- a/apps/web/src/components/mail/mail-sidebar-labels.test.ts
+++ b/apps/web/src/components/mail/mail-sidebar-labels.test.ts
@@ -1,30 +1,55 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import type { InvookLabel } from "@invook/contracts";
+
 import { listSidebarLabels } from "./mail-sidebar-labels";
+
+function label(overrides: Partial<InvookLabel> & Pick<InvookLabel, "id" | "name">): InvookLabel {
+  return {
+    description: "Requires a reply",
+    systemKey: null,
+    definitionVersion: 1,
+    isEnabled: true,
+    ...overrides,
+  };
+}
 
 test("sidebar labels contain only sorted Invook label definitions", () => {
   const labels = listSidebarLabels([
-    {
-      id: "custom-label",
-      name: "Action needed",
-      description: "Requires a reply",
-      systemKey: null,
-      definitionVersion: 1,
-      isEnabled: true,
-    },
-    {
+    label({ id: "custom-label", name: "Action needed" }),
+    label({
       id: "newsletter-label",
       name: "Newsletter",
       description: "Recurring editorial mail",
       systemKey: "newsletter",
-      definitionVersion: 1,
-      isEnabled: true,
-    },
+    }),
   ]);
 
   assert.deepEqual(labels, [
-    { id: "custom-label", name: "Action needed" },
-    { id: "newsletter-label", name: "Newsletter" },
+    { id: "custom-label", name: "Action needed", labelIds: ["custom-label"] },
+    {
+      id: "newsletter-label",
+      name: "Newsletter",
+      labelIds: ["newsletter-label"],
+    },
+  ]);
+});
+
+test("sidebar labels merge account labels that share one name", () => {
+  const labels = listSidebarLabels([
+    label({ id: "first-billing", name: "Billing", systemKey: "billing" }),
+    label({ id: "first-important", name: "Important", systemKey: "important" }),
+    label({ id: "second-billing", name: "billing", systemKey: "billing" }),
+    label({ id: "second-receipts", name: "Receipts" }),
+  ]);
+
+  assert.deepEqual(labels, [
+    {
+      id: "first-billing",
+      name: "Billing",
+      labelIds: ["first-billing", "second-billing"],
+    },
+    { id: "second-receipts", name: "Receipts", labelIds: ["second-receipts"] },
   ]);
 });

--- a/apps/web/src/components/mail/mail-sidebar-labels.ts
+++ b/apps/web/src/components/mail/mail-sidebar-labels.ts
@@ -1,15 +1,27 @@
-import type { InvookLabel } from "@invook/contracts";
+import { normalizeInvookLabelName, type InvookLabel } from "@invook/contracts";
 
 export interface SidebarLabel {
   id: string;
   name: string;
+  labelIds: string[];
 }
 
 export function listSidebarLabels(invookLabels: InvookLabel[]): SidebarLabel[] {
-  const labels = invookLabels.flatMap((label) =>
-    label.systemKey === "important"
-      ? []
-      : [{ id: label.id, name: label.name }],
+  const labelsByName = new Map<string, SidebarLabel>();
+  for (const label of invookLabels) {
+    if (label.systemKey === "important") continue;
+    const labelName = normalizeInvookLabelName(label.name);
+    const merged = labelsByName.get(labelName);
+    if (merged) merged.labelIds.push(label.id);
+    else {
+      labelsByName.set(labelName, {
+        id: label.id,
+        name: label.name,
+        labelIds: [label.id],
+      });
+    }
+  }
+  return [...labelsByName.values()].sort((left, right) =>
+    left.name.localeCompare(right.name),
   );
-  return labels.sort((left, right) => left.name.localeCompare(right.name));
 }

--- a/apps/web/src/components/mail/mail-sidebar-labels.ts
+++ b/apps/web/src/components/mail/mail-sidebar-labels.ts
@@ -1,4 +1,4 @@
-import { normalizeInvookLabelName, type InvookLabel } from "@invook/contracts";
+import type { MailboxAccountLabel } from "@invook/contracts";
 
 export interface SidebarLabel {
   id: string;
@@ -6,15 +6,16 @@ export interface SidebarLabel {
   labelIds: string[];
 }
 
-export function listSidebarLabels(invookLabels: InvookLabel[]): SidebarLabel[] {
+export function listSidebarLabels(
+  invookLabels: MailboxAccountLabel[],
+): SidebarLabel[] {
   const labelsByName = new Map<string, SidebarLabel>();
   for (const label of invookLabels) {
     if (label.systemKey === "important") continue;
-    const labelName = normalizeInvookLabelName(label.name);
-    const merged = labelsByName.get(labelName);
+    const merged = labelsByName.get(label.normalizedName);
     if (merged) merged.labelIds.push(label.id);
     else {
-      labelsByName.set(labelName, {
+      labelsByName.set(label.normalizedName, {
         id: label.id,
         name: label.name,
         labelIds: [label.id],

--- a/apps/web/src/components/mail/mail-sidebar.tsx
+++ b/apps/web/src/components/mail/mail-sidebar.tsx
@@ -145,10 +145,16 @@ export function MailSidebar({
       ? requestedView
       : "all";
   const currentSearchParams = new URLSearchParams(searchParams.toString());
-  const labelGroups = accounts.flatMap((account) => {
-    if (accountSelection !== "all" && account.id !== accountSelection) return [];
-    return [{ account, labels: listSidebarLabels(accountLabels(shell, account.id)) }];
-  });
+  const currentLabelId = currentView.startsWith("label:")
+    ? currentView.slice("label:".length)
+    : null;
+  const sidebarLabels = listSidebarLabels(
+    accounts.flatMap((account) =>
+      accountSelection !== "all" && account.id !== accountSelection
+        ? []
+        : accountLabels(shell, account.id),
+    ),
+  );
   const hrefFor = (updates: Parameters<typeof createMailboxHref>[1]): string =>
     createMailboxHref(currentSearchParams, updates);
   const handleAccountHref = (account: "all" | string): string =>
@@ -217,32 +223,23 @@ export function MailSidebar({
             href={hrefFor({ surface: null, thread: null, view: "important" })}
             count={currentCounts?.views.important}
           />
-          {labelGroups.map(({ account, labels }) => (
-            <div key={account.id}>
-              {accountSelection === "all" && accounts.length > 1 && labels.length > 0 ? (
-                <p className="mb-1 mt-2 hidden truncate px-2.5 text-[10px] font-medium text-sidebar-foreground/35 lg:block">
-                  {account.email}
-                </p>
-              ) : null}
-              {labels.map((label) => {
-                const view = `label:${label.id}` as const;
-                return (
-                  <NavLink
-                    key={label.id}
-                    label={label.name}
-                    icon={AiMagicIcon}
-                    active={currentSurface === "mail" && currentView === view}
-                    href={hrefFor({
-                      account: account.id,
-                      surface: null,
-                      thread: null,
-                      view,
-                    })}
-                    count={sidebarCounts?.accounts[account.id]?.labels[label.id]}
-                  />
-                );
+          {sidebarLabels.map((label) => (
+            <NavLink
+              key={label.id}
+              label={label.name}
+              icon={AiMagicIcon}
+              active={
+                currentSurface === "mail" &&
+                currentLabelId !== null &&
+                label.labelIds.includes(currentLabelId)
+              }
+              href={hrefFor({
+                surface: null,
+                thread: null,
+                view: `label:${label.id}`,
               })}
-            </div>
+              count={currentCounts?.labels[label.id]}
+            />
           ))}
         </nav>
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -55,6 +55,15 @@ export type InvookLabel = {
   isEnabled: boolean;
 };
 
+/**
+ * Invook labels are stored once per connected account, so the normalized name
+ * is the identity shared by the sibling labels that represent one user-facing
+ * label across accounts.
+ */
+export function normalizeInvookLabelName(name: string): string {
+  return name.trim().replace(/\s+/g, " ").toLocaleLowerCase();
+}
+
 export type LabelHistoryWindowDays = 7 | 30 | 90;
 
 export const LABEL_PREVIEW_STALE_ERROR =

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -365,9 +365,18 @@ export type MailboxSidebarCounts = {
   accounts: Record<string, MailboxScopeSidebarCounts>;
 };
 
+export type MailboxAccountLabel = InvookLabel & {
+  /**
+   * Stored identity that a mailbox label view matches on, so a client merging
+   * sibling labels across accounts follows the server instead of deriving a
+   * competing identity from the display name.
+   */
+  normalizedName: string;
+};
+
 export type MailboxAccountLabels = {
   accountId: string;
-  labels: InvookLabel[];
+  labels: MailboxAccountLabel[];
 };
 
 export type MailboxShell = {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -58,10 +58,12 @@ export type InvookLabel = {
 /**
  * Invook labels are stored once per connected account, so the normalized name
  * is the identity shared by the sibling labels that represent one user-facing
- * label across accounts.
+ * label across accounts. Case folding stays locale-independent because the
+ * server persists this value while the browser recomputes it, and a
+ * locale-sensitive rule would split one label into separate identities.
  */
 export function normalizeInvookLabelName(name: string): string {
-  return name.trim().replace(/\s+/g, " ").toLocaleLowerCase();
+  return name.trim().replace(/\s+/g, " ").toLowerCase();
 }
 
 export type LabelHistoryWindowDays = 7 | 30 | 90;

--- a/packages/contracts/src/invook-label-name.test.ts
+++ b/packages/contracts/src/invook-label-name.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeInvookLabelName } from "./index";
+
+test("label identity folds case and surrounding whitespace", () => {
+  assert.equal(normalizeInvookLabelName("  Action   Needed "), "action needed");
+  assert.equal(
+    normalizeInvookLabelName("BILLING"),
+    normalizeInvookLabelName("billing"),
+  );
+});
+
+test("label identity stays the same under a Turkish default locale", () => {
+  const dottedCapital = "İstanbul Invoices";
+  const dotlessCapital = "Irmak Invoices";
+  assert.equal(
+    normalizeInvookLabelName(dottedCapital),
+    dottedCapital.trim().toLowerCase(),
+  );
+  assert.equal(
+    normalizeInvookLabelName(dotlessCapital),
+    dotlessCapital.trim().toLowerCase(),
+  );
+  assert.notEqual(
+    normalizeInvookLabelName(dotlessCapital),
+    dotlessCapital.toLocaleLowerCase("tr-TR"),
+  );
+});

--- a/packages/database/src/mailbox-resources.ts
+++ b/packages/database/src/mailbox-resources.ts
@@ -1,17 +1,18 @@
-import type {
-  InvookLabel,
-  InvookThreadLabel,
-  MailboxAccount,
-  MailboxPagination,
-  MailboxSelectedThread,
-  MailboxSettings,
-  MailboxScopeSidebarCounts,
-  MailboxSidebarCounts,
-  MailboxThreadDetail,
-  MailboxThreadPage,
-  MailboxThreadSummary,
-  MailboxView,
-  StaticMailboxView,
+import {
+  normalizeInvookLabelName,
+  type InvookLabel,
+  type InvookThreadLabel,
+  type MailboxAccount,
+  type MailboxPagination,
+  type MailboxSelectedThread,
+  type MailboxSettings,
+  type MailboxScopeSidebarCounts,
+  type MailboxSidebarCounts,
+  type MailboxThreadDetail,
+  type MailboxThreadPage,
+  type MailboxThreadSummary,
+  type MailboxView,
+  type StaticMailboxView,
 } from "@invook/contracts";
 import {
   and,
@@ -469,7 +470,22 @@ export async function getMailboxSidebarCounts(
     for (const view of Object.keys(all.views) as StaticMailboxView[]) {
       all.views[view] += counts.views[view];
     }
-    Object.assign(all.labels, counts.labels);
+  }
+  // Sibling labels share one name across accounts, so the All scope reports the
+  // combined total under each account label id that carries that name.
+  const labelTotalsByName = new Map<string, number>();
+  for (const label of invookLabels) {
+    const labelName = normalizeInvookLabelName(label.name);
+    const accountCount =
+      countsByAccountId.get(label.accountId)?.labels[label.id] ?? 0;
+    labelTotalsByName.set(
+      labelName,
+      (labelTotalsByName.get(labelName) ?? 0) + accountCount,
+    );
+  }
+  for (const label of invookLabels) {
+    all.labels[label.id] =
+      labelTotalsByName.get(normalizeInvookLabelName(label.name)) ?? 0;
   }
   return {
     all,

--- a/packages/database/src/mailbox-resources.ts
+++ b/packages/database/src/mailbox-resources.ts
@@ -2,6 +2,7 @@ import type {
   InvookLabel,
   InvookThreadLabel,
   MailboxAccount,
+  MailboxAccountLabel,
   MailboxPagination,
   MailboxSelectedThread,
   MailboxSettings,
@@ -204,10 +205,7 @@ async function listInvookLabels(
   return rows.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-type AccountInvookLabel = InvookLabel & {
-  accountId: string;
-  normalizedName: string;
-};
+type AccountInvookLabel = MailboxAccountLabel & { accountId: string };
 
 async function listInvookLabelsForAccounts(
   input: { userId: string; accountIds: string[] },
@@ -338,7 +336,7 @@ export async function getMailboxShellData(
   database: Database = getDatabase(),
 ): Promise<{
   accounts: MailboxAccount[];
-  accountLabels: Array<{ accountId: string; labels: InvookLabel[] }>;
+  accountLabels: Array<{ accountId: string; labels: MailboxAccountLabel[] }>;
 } | null> {
   const accounts = await listMailboxAccountContexts(userId, database);
   if (accounts.length === 0) return null;
@@ -352,10 +350,7 @@ export async function getMailboxShellData(
       accountId: account.id,
       labels: invookLabels
         .filter((label) => label.accountId === account.id)
-        .map(
-          ({ accountId: _accountId, normalizedName: _normalizedName, ...label }) =>
-            label,
-        ),
+        .map(({ accountId: _accountId, ...label }) => label),
     })),
   };
 }

--- a/packages/database/src/mailbox-resources.ts
+++ b/packages/database/src/mailbox-resources.ts
@@ -1,18 +1,17 @@
-import {
-  normalizeInvookLabelName,
-  type InvookLabel,
-  type InvookThreadLabel,
-  type MailboxAccount,
-  type MailboxPagination,
-  type MailboxSelectedThread,
-  type MailboxSettings,
-  type MailboxScopeSidebarCounts,
-  type MailboxSidebarCounts,
-  type MailboxThreadDetail,
-  type MailboxThreadPage,
-  type MailboxThreadSummary,
-  type MailboxView,
-  type StaticMailboxView,
+import type {
+  InvookLabel,
+  InvookThreadLabel,
+  MailboxAccount,
+  MailboxPagination,
+  MailboxSelectedThread,
+  MailboxSettings,
+  MailboxScopeSidebarCounts,
+  MailboxSidebarCounts,
+  MailboxThreadDetail,
+  MailboxThreadPage,
+  MailboxThreadSummary,
+  MailboxView,
+  StaticMailboxView,
 } from "@invook/contracts";
 import {
   and,
@@ -205,7 +204,10 @@ async function listInvookLabels(
   return rows.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-type AccountInvookLabel = InvookLabel & { accountId: string };
+type AccountInvookLabel = InvookLabel & {
+  accountId: string;
+  normalizedName: string;
+};
 
 async function listInvookLabelsForAccounts(
   input: { userId: string; accountIds: string[] },
@@ -217,6 +219,7 @@ async function listInvookLabelsForAccounts(
       accountId: labels.accountId,
       id: labels.id,
       name: labels.name,
+      normalizedName: labels.normalizedName,
       description: labels.description,
       systemKey: labels.systemKey,
       definitionVersion: labels.definitionVersion,
@@ -349,7 +352,10 @@ export async function getMailboxShellData(
       accountId: account.id,
       labels: invookLabels
         .filter((label) => label.accountId === account.id)
-        .map(({ accountId: _accountId, ...label }) => label),
+        .map(
+          ({ accountId: _accountId, normalizedName: _normalizedName, ...label }) =>
+            label,
+        ),
     })),
   };
 }
@@ -471,21 +477,20 @@ export async function getMailboxSidebarCounts(
       all.views[view] += counts.views[view];
     }
   }
-  // Sibling labels share one name across accounts, so the All scope reports the
-  // combined total under each account label id that carries that name.
+  // Sibling labels share one stored normalized name across accounts, the same
+  // identity a label view matches, so the All scope reports the combined total
+  // under each account label id that carries that name.
   const labelTotalsByName = new Map<string, number>();
   for (const label of invookLabels) {
-    const labelName = normalizeInvookLabelName(label.name);
     const accountCount =
       countsByAccountId.get(label.accountId)?.labels[label.id] ?? 0;
     labelTotalsByName.set(
-      labelName,
-      (labelTotalsByName.get(labelName) ?? 0) + accountCount,
+      label.normalizedName,
+      (labelTotalsByName.get(label.normalizedName) ?? 0) + accountCount,
     );
   }
   for (const label of invookLabels) {
-    all.labels[label.id] =
-      labelTotalsByName.get(normalizeInvookLabelName(label.name)) ?? 0;
+    all.labels[label.id] = labelTotalsByName.get(label.normalizedName) ?? 0;
   }
   return {
     all,

--- a/packages/database/src/mailbox-visibility.ts
+++ b/packages/database/src/mailbox-visibility.ts
@@ -28,6 +28,7 @@ export const countedGmailProviderLabelIds = Object.values(
 
 const outerThreadId = sql.raw('"threads"."id"');
 const outerThreadAccountId = sql.raw('"threads"."account_id"');
+const outerThreadUserId = sql.raw('"threads"."user_id"');
 
 export function inboxThreadCondition() {
   return sql<boolean>`exists (
@@ -55,12 +56,24 @@ export function visibleThreadCondition() {
 export function mailboxViewCondition(view: MailboxView) {
   if (view.startsWith("label:")) {
     const labelId = view.slice(6);
+    // One Invook label exists per connected account, so the view matches every
+    // account label the signed-in user owns under the selected label's name.
     return sql<boolean>`
       (${inboxThreadCondition()}) and exists (
         select 1 from ${threadLabelAssignments} assignment
+        inner join ${labels} assignment_label
+          on assignment_label.id = assignment.label_id
         where assignment.thread_id = ${outerThreadId}
           and assignment.account_id = ${outerThreadAccountId}
-          and assignment.label_id = ${labelId}::uuid
+          and assignment_label.account_id = ${outerThreadAccountId}
+          and assignment_label.kind = 'invook'
+          and assignment_label.normalized_name = (
+            select selected_label.normalized_name
+            from ${labels} selected_label
+            where selected_label.id = ${labelId}::uuid
+              and selected_label.user_id = ${outerThreadUserId}
+              and selected_label.kind = 'invook'
+          )
       )
     `;
   }

--- a/packages/database/src/repositories.ts
+++ b/packages/database/src/repositories.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import {
+  normalizeInvookLabelName,
   type LabelHistoryWindowDays,
   type MailSyncProgress,
 } from "@invook/contracts";
@@ -1855,10 +1856,6 @@ export class LabelMutationError extends Error {
   }
 }
 
-function normalizeLabelName(value: string) {
-  return value.trim().replace(/\s+/g, " ").toLocaleLowerCase();
-}
-
 function isUniqueViolation(error: unknown) {
   return Boolean(
     error &&
@@ -1896,7 +1893,7 @@ export async function createInvookLabel(
         .limit(1);
       if (!account) return null;
 
-      const normalizedName = normalizeLabelName(input.name);
+      const normalizedName = normalizeInvookLabelName(input.name);
       const [existing] = await transaction
         .select({ id: labels.id })
         .from(labels)
@@ -1993,7 +1990,7 @@ export async function updateInvookLabel(
       .update(labels)
       .set({
         name: input.name.trim().replace(/\s+/g, " "),
-        normalizedName: normalizeLabelName(input.name),
+        normalizedName: normalizeInvookLabelName(input.name),
         description: input.description.trim().replace(/\s+/g, " "),
         definitionVersion: sql`${labels.definitionVersion} + 1`,
         updatedAt: new Date(),


### PR DESCRIPTION
## Summary

- The sidebar renders one merged label list instead of repeating the same labels under an account-email heading for every connected inbox. Labels that share a name across accounts collapse into a single entry.
- The All inbox scope now reports the combined label total across accounts. Previously `all.labels` merged the per-account maps without summing, so an All-scope label count showed a single account's number while the Mail view counts beside it were already aggregated.
- A `label:` mailbox view now matches every label the signed-in user owns under the selected label's normalized name, so clicking a merged label under All lists threads from every account rather than one.
- Label-name normalization moved into `@invook/contracts` as `normalizeInvookLabelName`, and label writes, the count aggregation, and the sidebar merge all use it, so the grouping key has one definition.

Sidebar view counts (All, Starred, Drafts, Sent, Spam, Trash) are unchanged; they were already summed across accounts.

## Test plan

- [x] `pnpm typecheck` across the workspace
- [x] `pnpm test` (web 61, api 67, contracts and database unit suites)
- [x] `pnpm --filter @invook/web lint`
- [x] Rendered the new label-view SQL and ran `EXPLAIN` against the local schema to confirm it is valid
- [x] Reproduced the count math in PostgreSQL: per-account label counts match the pre-change sidebar exactly, and per-name totals equal the sum across accounts
- [x] Rebuilt the local Docker stack; web and API both serve 200
- [ ] Visual confirmation in a signed-in browser that the Labels section shows one merged list and that clicking a label under All lists threads from multiple accounts