### PR TITLE
Support shared Gmail connections across Invook users

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Open [localhost:3000](http://localhost:3000), sign in with Google, then connect 
 
 Gmail owns your messages, read state, stars, and drafts. Invook writes provider actions to Gmail first, then brings its stored replica up to date through Gmail history. Invook owns your AI labels, editable Memory, and local reply drafts.
 
+The same Gmail mailbox can be connected by multiple Invook users. Each user must independently complete Gmail authorization; credentials, replicas, attachments, Invook labels, Memory, and preferences remain isolated by their internal connection IDs. Provider actions still change the real shared mailbox and converge through each connection's own history cursor. Verified push notifications fan out to every active connection; a busy replica requests redelivery without undoing other admissions.
+
+Disconnect removes only that user's connection and local data. Watch operations are serialized by Gmail identity, and cleanup stops the provider watch only when no other connected or reconnect-required connection needs it. Reconnecting a connection still being removed requires waiting for cleanup to finish. Invook does not revoke the shared Google application grant on disconnect.
+
 Automatic labeling considers Inbox threads with an Inbox message from the last 14 days and uses individual model calls, including during initial sync. Older mail still syncs, but does not start automatic labeling. OpenAI Batch is used for labels only when you explicitly choose to apply a label to past mail in Settings (7, 30, or 90 days); that request considers only the selected label and preserves nonmatches. Gmail categories, custom labels, and Gmail Important are not imported as Invook labels. Operational Gmail state such as read, star, Inbox, and draft status remains synchronized.
 
 Mailbox data lives in your configured PostgreSQL database; attachment bytes live in S3-compatible storage. AI features send the mail context they need to the providers you configure. Self-hosting does not mean every operation stays on your machine.
@@ -109,6 +113,8 @@ Sender-hosted images currently load directly from their original URLs. Opening a
 ## Built for contributors
 
 When upgrading across the label-policy migration, stop API and worker processes before migrating, then restart them together with the updated web build. The migration retires automatic label jobs, preserves completed assignments and pending explicit settings requests, and removes imported Gmail label metadata. The worker resumes eligible recent labeling and saved settings requests after startup.
+
+Shared-mailbox support adds migration `0038_shared_gmail_connections` after label-policy migrations 0036/0037. Apply them in order with API and workers stopped, then deploy the updated API, worker, and web together. Do not run the older single-recipient push or unconditional watch-stop implementation after enabling multi-user connections. Migration 0038 preserves existing IDs and data while changing provider-identity uniqueness to `(user_id, provider, provider_account_id)`.
 
 **TypeScript throughout.** Next.js and React on the web, Fastify at the API, PostgreSQL with Drizzle for persistence, and Temporal Cloud for durable work.
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "node ../../scripts/run-with-root-env.mjs node_modules/tsx/dist/cli.mjs watch src/index.ts",
     "start": "node ../../scripts/run-with-root-env.mjs node_modules/tsx/dist/cli.mjs src/index.ts",
-    "test": "node --import tsx --test src/*.test.ts src/services/*.test.ts",
+    "test": "node --import tsx --test src/*.test.ts src/services/*.test.ts src/routes/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -529,7 +529,7 @@ test("Gmail connection identities preserve user and reconnect ownership", () => 
       reconnectAccount: null,
       existingAccount: otherUserAccount,
     }),
-    "already_connected",
+    "mailbox_mismatch",
   );
   assert.equal(
     getGmailConnectionIdentityError({
@@ -737,8 +737,8 @@ test("Google Pub/Sub retries busy admission and acknowledges only stored deliver
           notificationHistoryId: "150",
         });
         return isBusy
-          ? { status: "retry" }
-          : { status: "queued", accountId: attachmentOwnerId, stepId: attachmentId };
+          ? { status: "retry", connections: [{ status: "retry" }] }
+          : { status: "accepted", connections: [{ status: "queued", accountId: attachmentOwnerId, stepId: attachmentId }] };
       },
     });
     const payload = {

--- a/apps/api/src/routes/gmail-connections.test.ts
+++ b/apps/api/src/routes/gmail-connections.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { encryptGoogleCredential } from "@invook/database";
+
+import {
+  getGmailConnectionIdentityError,
+  resolveGmailRefreshToken,
+} from "./gmail-connections";
+
+test("omitted Google refresh tokens only fall back to this user's own grant", () => {
+  const encryptionKey = Buffer.alloc(32, 8).toString("base64");
+  const existingAccount = {
+    userId: "user-a",
+    tokenCiphertext: encryptGoogleCredential(
+      {
+        accessToken: "access-a",
+        refreshToken: "refresh-a",
+        expiresAt: "2030-01-01T00:00:00Z",
+        scopes: [],
+      },
+      encryptionKey,
+    ),
+  };
+  assert.equal(
+    resolveGmailRefreshToken({
+      userId: "user-a",
+      refreshToken: null,
+      existingAccount,
+      encryptionKey,
+    }),
+    "refresh-a",
+  );
+  assert.equal(
+    resolveGmailRefreshToken({
+      userId: "user-b",
+      refreshToken: null,
+      existingAccount,
+      encryptionKey,
+    }),
+    null,
+  );
+  assert.equal(
+    resolveGmailRefreshToken({
+      userId: "user-b",
+      refreshToken: "refresh-b",
+      existingAccount: null,
+      encryptionKey,
+    }),
+    "refresh-b",
+  );
+  assert.equal(
+    resolveGmailRefreshToken({
+      userId: "user-b",
+      refreshToken: null,
+      existingAccount: null,
+      encryptionKey,
+    }),
+    null,
+  );
+});
+
+test("each user's own connection is accepted while reconnect keeps identity and ownership checks", () => {
+  for (const userId of ["user-a", "user-b"]) {
+    const connection = {
+      id: `${userId}-mailbox-a`,
+      userId,
+      providerAccountId: "gmail-a",
+    };
+    for (const reconnectAccount of [null, connection]) {
+      assert.equal(
+        getGmailConnectionIdentityError({
+          userId,
+          providerAccountId: "gmail-a",
+          reconnectAccount,
+          existingAccount: connection,
+        }),
+        null,
+      );
+    }
+    assert.equal(
+      getGmailConnectionIdentityError({
+        userId,
+        providerAccountId: "gmail-c",
+        reconnectAccount: connection,
+        existingAccount: null,
+      }),
+      "mailbox_mismatch",
+    );
+    assert.equal(
+      getGmailConnectionIdentityError({
+        userId: "someone-else",
+        providerAccountId: "gmail-a",
+        reconnectAccount: connection,
+        existingAccount: connection,
+      }),
+      "mailbox_mismatch",
+    );
+  }
+});

--- a/apps/api/src/routes/gmail-connections.ts
+++ b/apps/api/src/routes/gmail-connections.ts
@@ -10,8 +10,10 @@ import {
   encryptGoogleCredential,
   getGmailConnectionForOAuth,
   getGmailConnectionForUser,
+  GmailConnectionDeletingError,
   refreshGmailAuthentication,
   saveNewGmailConnection,
+  withGmailIdentityLock,
 } from "@invook/database";
 import {
   createGoogleAuthorizationRequest,
@@ -31,7 +33,7 @@ import { sendProblem, sendRedirect } from "../responses";
 const CONNECTION_REQUEST_DURATION_MILLISECONDS = 10 * 60 * 1_000;
 
 type ConnectionErrorReason =
-  | "already_connected"
+  | "disconnect_pending"
   | "authorization"
   | "configuration"
   | "gmail_access"
@@ -58,7 +60,7 @@ export function getGmailConnectionIdentityError(input: {
   providerAccountId: string;
   reconnectAccount: GmailConnectionIdentity | null;
   existingAccount: { id: string; userId: string } | null;
-}): "already_connected" | "mailbox_mismatch" | null {
+}): "mailbox_mismatch" | null {
   if (
     input.reconnectAccount &&
     (input.reconnectAccount.userId !== input.userId ||
@@ -68,9 +70,30 @@ export function getGmailConnectionIdentityError(input: {
     return "mailbox_mismatch";
   }
   if (input.existingAccount && input.existingAccount.userId !== input.userId) {
-    return "already_connected";
+    return "mailbox_mismatch";
   }
   return null;
+}
+
+export function resolveGmailRefreshToken(input: {
+  userId: string;
+  refreshToken: string | null;
+  existingAccount: { userId: string; tokenCiphertext: string | null } | null;
+  encryptionKey: string;
+}): string | null {
+  if (input.refreshToken) return input.refreshToken;
+  // Defense in depth: a missing Google refresh token never permits borrowing
+  // another user's grant, even if a future caller supplies the wrong account.
+  if (
+    input.existingAccount?.userId !== input.userId ||
+    !input.existingAccount.tokenCiphertext
+  ) {
+    return null;
+  }
+  return decryptGoogleCredential(
+    input.existingAccount.tokenCiphertext,
+    input.encryptionKey,
+  ).refreshToken;
 }
 
 function connectionErrorUrl(reason: ConnectionErrorReason): string {
@@ -98,7 +121,8 @@ async function handleGmailStart(
   const requestedAccountId = request.query.accountId;
   if (
     requestedAccountId !== undefined &&
-    (typeof requestedAccountId !== "string" || !validateUuid(requestedAccountId))
+    (typeof requestedAccountId !== "string" ||
+      !validateUuid(requestedAccountId))
   ) {
     await sendProblem(request, reply, 400, "Invalid Gmail account ID");
     return;
@@ -129,9 +153,7 @@ async function handleGmailStart(
     codeVerifier: authorization.codeVerifier,
     userId: session.userId,
     accountId,
-    expiresAt: new Date(
-      Date.now() + CONNECTION_REQUEST_DURATION_MILLISECONDS,
-    ),
+    expiresAt: new Date(Date.now() + CONNECTION_REQUEST_DURATION_MILLISECONDS),
   });
   await sendRedirect(reply, authorization.url, 302);
 }
@@ -145,7 +167,8 @@ async function handleGmailCallback(
 
   const providerError =
     typeof request.query.error === "string" ? request.query.error : null;
-  const code = typeof request.query.code === "string" ? request.query.code : null;
+  const code =
+    typeof request.query.code === "string" ? request.query.code : null;
   const returnedState =
     typeof request.query.state === "string" ? request.query.state : null;
   const connectionRequest = returnedState
@@ -175,88 +198,110 @@ async function handleGmailCallback(
     });
     const gmailProfile = await getGmailProfile(authorization.accessToken);
     const providerAccountId = authorization.identity.subject;
-    const existingAccount = await getGmailConnectionForOAuth(providerAccountId);
-
-    const reconnectAccount = connectionRequest.accountId
-      ? await getGmailConnectionForUser({
-        userId: session.userId,
-        accountId: connectionRequest.accountId,
-      })
-      : null;
-    if (connectionRequest.accountId && !reconnectAccount) {
-      await sendRedirect(reply, connectionErrorUrl("mailbox_mismatch"), 302);
-      return;
-    }
-    const identityError = getGmailConnectionIdentityError({
-      userId: session.userId,
+    const account = await withGmailIdentityLock(
       providerAccountId,
-      reconnectAccount,
-      existingAccount,
-    });
-    if (identityError) {
-      await sendRedirect(reply, connectionErrorUrl(identityError), 302);
-      return;
-    }
+      async (transaction) => {
+        const existingAccount = await getGmailConnectionForOAuth(
+          {
+            userId: session.userId,
+            providerAccountId,
+          },
+          transaction,
+        );
 
-    let refreshToken = authorization.refreshToken;
-    if (!refreshToken && existingAccount?.tokenCiphertext) {
-      refreshToken = decryptGoogleCredential(
-        existingAccount.tokenCiphertext,
-        process.env.TOKEN_ENCRYPTION_KEY ?? "",
-      ).refreshToken;
-    }
-    if (!refreshToken) {
-      await sendRedirect(reply, connectionErrorUrl("offline_access"), 302);
-      return;
-    }
+        const reconnectAccount = connectionRequest.accountId
+          ? await getGmailConnectionForUser(
+              {
+                userId: session.userId,
+                accountId: connectionRequest.accountId,
+              },
+              transaction,
+            )
+          : null;
+        if (connectionRequest.accountId && !reconnectAccount) {
+          await sendRedirect(
+            reply,
+            connectionErrorUrl("mailbox_mismatch"),
+            302,
+          );
+          return;
+        }
+        const identityError = getGmailConnectionIdentityError({
+          userId: session.userId,
+          providerAccountId,
+          reconnectAccount,
+          existingAccount,
+        });
+        if (identityError) {
+          await sendRedirect(reply, connectionErrorUrl(identityError), 302);
+          return;
+        }
 
-    const authenticatedAt = new Date();
-    const tokenCiphertext = encryptGoogleCredential(
-      {
-        accessToken: authorization.accessToken,
-        refreshToken,
-        expiresAt: authorization.expiresAt,
-        scopes: authorization.scopes,
+        const refreshToken = resolveGmailRefreshToken({
+          userId: session.userId,
+          refreshToken: authorization.refreshToken,
+          existingAccount,
+          encryptionKey: process.env.TOKEN_ENCRYPTION_KEY ?? "",
+        });
+        if (!refreshToken) {
+          await sendRedirect(reply, connectionErrorUrl("offline_access"), 302);
+          return;
+        }
+
+        const authenticatedAt = new Date();
+        const tokenCiphertext = encryptGoogleCredential(
+          {
+            accessToken: authorization.accessToken,
+            refreshToken,
+            expiresAt: authorization.expiresAt,
+            scopes: authorization.scopes,
+          },
+          process.env.TOKEN_ENCRYPTION_KEY ?? "",
+        );
+        const authentication = {
+          userId: session.userId,
+          providerAccountId,
+          email: gmailProfile.emailAddress,
+          image: authorization.identity.image,
+          scopes: authorization.scopes,
+          currentHistoryId: gmailProfile.historyId,
+          tokenCiphertext,
+          authenticatedAt,
+        };
+        let account = existingAccount
+          ? await refreshGmailAuthentication(authentication, transaction)
+          : null;
+        if (!account) {
+          const topicName = process.env.GMAIL_PUBSUB_TOPIC;
+          if (!topicName) {
+            throw new Error("GMAIL_PUBSUB_TOPIC is required to connect Gmail.");
+          }
+          const watch = await startGmailWatch(authorization.accessToken, {
+            topicName,
+          });
+          const watchExpiration = Number(watch.expiration);
+          if (!Number.isFinite(watchExpiration)) {
+            throw new Error("Gmail returned an invalid watch expiration.");
+          }
+          const watchRenewedAt = new Date();
+          account = await saveNewGmailConnection(
+            {
+              ...authentication,
+              initialHistoryId: gmailProfile.historyId,
+              watch: {
+                topicName,
+                historyId: watch.historyId,
+                expirationAt: new Date(watchExpiration),
+                renewedAt: watchRenewedAt,
+              },
+            },
+            transaction,
+          );
+        }
+        return account;
       },
-      process.env.TOKEN_ENCRYPTION_KEY ?? "",
     );
-    const authentication = {
-      userId: session.userId,
-      providerAccountId,
-      email: gmailProfile.emailAddress,
-      image: authorization.identity.image,
-      scopes: authorization.scopes,
-      currentHistoryId: gmailProfile.historyId,
-      tokenCiphertext,
-      authenticatedAt,
-    };
-    let account = existingAccount
-      ? await refreshGmailAuthentication(authentication)
-      : null;
-    if (!account) {
-      const topicName = process.env.GMAIL_PUBSUB_TOPIC;
-      if (!topicName) {
-        throw new Error("GMAIL_PUBSUB_TOPIC is required to connect Gmail.");
-      }
-      const watch = await startGmailWatch(authorization.accessToken, {
-        topicName,
-      });
-      const watchExpiration = Number(watch.expiration);
-      if (!Number.isFinite(watchExpiration)) {
-        throw new Error("Gmail returned an invalid watch expiration.");
-      }
-      const watchRenewedAt = new Date();
-      account = await saveNewGmailConnection({
-        ...authentication,
-        initialHistoryId: gmailProfile.historyId,
-        watch: {
-          topicName,
-          historyId: watch.historyId,
-          expirationAt: new Date(watchExpiration),
-          renewedAt: watchRenewedAt,
-        },
-      });
-    }
+    if (!account) return;
 
     const mailboxUrl = new URL("/mail", getPublicAppOrigin());
     mailboxUrl.searchParams.set("account", account.id);
@@ -265,22 +310,25 @@ async function handleGmailCallback(
     console.error("api: gmail connection callback failed", {
       requestId: request.id,
       name: error instanceof Error ? error.name : "UnknownError",
-      message: error instanceof Error ? error.message : "Unknown callback failure",
       status: error instanceof GmailApiError ? error.status : undefined,
     });
     await sendRedirect(
       reply,
       connectionErrorUrl(
-        error instanceof GmailApiError && error.status === 403
-          ? "gmail_access"
-          : "unknown",
+        error instanceof GmailConnectionDeletingError
+          ? "disconnect_pending"
+          : error instanceof GmailApiError && error.status === 403
+            ? "gmail_access"
+            : "unknown",
       ),
       302,
     );
   }
 }
 
-export const registerGmailConnectionRoutes: FastifyPluginAsync = async (api) => {
+export const registerGmailConnectionRoutes: FastifyPluginAsync = async (
+  api,
+) => {
   api.get<{ Querystring: StartQuery }>(
     "/v1/connections/gmail/start",
     { onRequest: requireSession },

--- a/apps/web/src/app/auth/error/page.tsx
+++ b/apps/web/src/app/auth/error/page.tsx
@@ -9,7 +9,7 @@ type AuthenticationErrorPageProps = {
 };
 
 const messages: Record<string, string> = {
-  already_connected: "That Gmail mailbox is already connected to another Invook user.",
+  disconnect_pending: "This Gmail connection is still being removed. Try connecting again after it finishes.",
   authorization: "The Gmail connection request could not be verified.",
   configuration:
     "Google OAuth and Gmail synchronization are not fully configured for this installation.",

--- a/apps/web/src/components/mail/mail-account-avatar.tsx
+++ b/apps/web/src/components/mail/mail-account-avatar.tsx
@@ -56,7 +56,7 @@ export function MailAccountAvatar({
       title={account.email}
       aria-label={account.email}
       className={cn(
-        "size-5 border-0 ring-2 ring-offset-1 after:border-0",
+        "size-5 border-0 ring-1 ring-offset-1 after:border-0",
         accountRingClassName(account.id, accounts),
         ringOffsetClassName,
         className,

--- a/apps/web/src/components/mail/mail-list.tsx
+++ b/apps/web/src/components/mail/mail-list.tsx
@@ -176,15 +176,15 @@ function MailRow({
       </div>
 
       <div className="flex min-w-0 items-center justify-end gap-2">
+        <LocalMailDate
+          className="min-w-0 whitespace-nowrap text-right text-xs tabular-nums text-muted-foreground"
+          value={thread.latestMessageAt}
+        />
         <MailAccountAvatar
           account={account}
           accounts={accounts}
           user={user}
           className="size-4.5"
-        />
-        <LocalMailDate
-          className="min-w-0 whitespace-nowrap text-right text-xs tabular-nums text-muted-foreground"
-          value={thread.latestMessageAt}
         />
       </div>
     </Link>

--- a/apps/web/src/components/mail/mail-sidebar.tsx
+++ b/apps/web/src/components/mail/mail-sidebar.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import {
-  AiMagicIcon,
   Delete02Icon,
   FileEditIcon,
   InboxIcon,
-  LabelImportantIcon,
   Mail01Icon,
   PencilEdit01Icon,
   PlusSignIcon,
@@ -17,9 +15,7 @@ import {
   WorkflowSquare01Icon,
 } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import type {
-  MailboxSidebarCounts,
-} from "@invook/contracts";
+import type { MailboxSidebarCounts } from "@invook/contracts";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 
@@ -68,7 +64,7 @@ const mailItems = [
 
 interface NavLinkProps {
   label: string;
-  icon: typeof Mail01Icon;
+  icon?: typeof Mail01Icon;
   active: boolean;
   href: string;
   count?: number;
@@ -93,9 +89,16 @@ function NavLink({
     <Link
       href={href}
       aria-current={active ? "page" : undefined}
-      className={navItemClassName(active)}
+      className={cn(navItemClassName(active), !icon && "hidden lg:flex")}
     >
-      <HugeiconsIcon icon={icon} size={15} strokeWidth={1.65} className="shrink-0" />
+      {icon ? (
+        <HugeiconsIcon
+          icon={icon}
+          size={15}
+          strokeWidth={1.65}
+          className="shrink-0"
+        />
+      ) : null}
       <span className="hidden min-w-0 flex-1 truncate lg:block">{label}</span>
       {count === undefined ? null : (
         <span className="hidden shrink-0 text-[11px] font-normal tabular-nums text-sidebar-foreground/38 lg:block">
@@ -218,7 +221,6 @@ export function MailSidebar({
         <nav className="space-y-0.5" aria-label="Labels">
           <NavLink
             label="Important"
-            icon={LabelImportantIcon}
             active={currentSurface === "mail" && currentView === "important"}
             href={hrefFor({ surface: null, thread: null, view: "important" })}
             count={currentCounts?.views.important}
@@ -227,7 +229,6 @@ export function MailSidebar({
             <NavLink
               key={label.id}
               label={label.name}
-              icon={AiMagicIcon}
               active={
                 currentSurface === "mail" &&
                 currentLabelId !== null &&

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -23,6 +23,8 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
+    "drizzle-orm": "^0.45.2",
+    "postgres": "^3.4.7",
     "tsx": "^4.20.0",
     "typescript": "^5.9.0"
   }

--- a/apps/worker/src/gmail-watch-lifecycle.test.ts
+++ b/apps/worker/src/gmail-watch-lifecycle.test.ts
@@ -1,0 +1,460 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import test, { type TestContext } from "node:test";
+
+import { and, eq, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { v4 as uuidv4 } from "uuid";
+
+import * as schema from "@invook/database";
+import {
+  accountSecrets,
+  connectedAccounts,
+  encryptGoogleCredential,
+  gmailWatchStates,
+  markGmailReplicaDeleting,
+  messageAttachments,
+  messages,
+  profiles,
+  saveNewGmailConnection,
+  threads,
+  withGmailIdentityLock,
+  workflowSteps,
+} from "@invook/database";
+
+import {
+  GmailConnectionInactiveError,
+  renewGmailConnectionWatch,
+  runGmailConnectionCleanup,
+} from "./gmail-watch-lifecycle";
+
+const testDatabaseUrl = process.env.TEST_DATABASE_URL;
+const encryptionKey = Buffer.alloc(32, 5).toString("base64");
+
+function createBarrier(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = () => {};
+  const promise = new Promise<void>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+async function setup(t: TestContext) {
+  assert.ok(testDatabaseUrl);
+  const testSchema = `watch_lifecycle_${uuidv4().replaceAll("-", "")}`;
+  const client = postgres(testDatabaseUrl, {
+    max: 4,
+    prepare: false,
+    onnotice: () => {},
+    connection: { search_path: `${testSchema},public` },
+  });
+  const database = drizzle(client, { schema });
+  t.after(async () => {
+    await client.unsafe(`DROP SCHEMA IF EXISTS "${testSchema}" CASCADE`);
+    await client.end();
+  });
+  await client.unsafe(`CREATE SCHEMA "${testSchema}"`);
+  await client.unsafe(
+    "CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public",
+  );
+  const migrationsUrl = new URL(
+    "../../../packages/database/drizzle/",
+    import.meta.url,
+  );
+  for (const filename of (await readdir(migrationsUrl))
+    .filter((name) => /^\d{4}_.+\.sql$/.test(name))
+    .sort()) {
+    const migration = await readFile(new URL(filename, migrationsUrl), "utf8");
+    for (const statement of migration
+      .replaceAll('"public".', `"${testSchema}".`)
+      .split("--> statement-breakpoint")) {
+      if (statement.trim()) await client.unsafe(statement);
+    }
+  }
+  const userIds = [uuidv4(), uuidv4()];
+  const [userA, userB] = userIds;
+  assert.ok(userA && userB);
+  const providerAccountId = uuidv4();
+  await database.insert(profiles).values(
+    userIds.map((id) => ({
+      id,
+      email: `${id}@example.test`,
+      displayName: "Lifecycle test",
+    })),
+  );
+  const authentication = (userId: string) => ({
+    userId,
+    providerAccountId,
+    email: `${providerAccountId}@example.test`,
+    image: null,
+    scopes: [],
+    currentHistoryId: "100",
+    initialHistoryId: "100",
+    authenticatedAt: new Date(),
+    tokenCiphertext: encryptGoogleCredential(
+      {
+        accessToken: `access-${userId}`,
+        refreshToken: `refresh-${userId}`,
+        expiresAt: "2030-01-01T00:00:00Z",
+        scopes: [],
+      },
+      encryptionKey,
+    ),
+    watch: {
+      topicName: "projects/test/topics/gmail",
+      historyId: "100",
+      expirationAt: new Date("2030-01-08T00:00:00Z"),
+      renewedAt: new Date("2030-01-01T00:00:00Z"),
+    },
+  });
+  const first = await saveNewGmailConnection(authentication(userA), database);
+  const disconnect = async (accountId: string, userId: string) => {
+    const cleanupId = await markGmailReplicaDeleting(
+      { accountId, userId },
+      database,
+    );
+    assert.ok(cleanupId);
+    const [step] = await database
+      .select()
+      .from(workflowSteps)
+      .where(
+        and(
+          eq(workflowSteps.accountId, accountId),
+          eq(workflowSteps.stepType, "gmail.account.cleanup"),
+        ),
+      );
+    assert.ok(step);
+    return { accountId, userId, cleanupId, stepId: step.id };
+  };
+  return {
+    database,
+    client,
+    userA,
+    userB,
+    first,
+    providerAccountId,
+    authentication,
+    disconnect,
+  };
+}
+
+test(
+  "cleanup of one connection preserves the other user's watch, credentials and stored objects",
+  { skip: !testDatabaseUrl },
+  async (t) => {
+    const { database, userA, userB, first, authentication, disconnect } =
+      await setup(t);
+    const second = await saveNewGmailConnection(
+      authentication(userB),
+      database,
+    );
+    const keys = new Map<string, string>();
+    for (const { id: accountId, userId } of [
+      { ...first, userId: userA },
+      { ...second, userId: userB },
+    ]) {
+      const threadId = uuidv4();
+      const messageId = uuidv4();
+      const objectKey = `${accountId}/messages/shared/attachments/0-checksum`;
+      keys.set(accountId, objectKey);
+      await database.insert(threads).values({
+        id: threadId,
+        userId,
+        accountId,
+        providerThreadId: "shared",
+      });
+      await database.insert(messages).values({
+        id: messageId,
+        threadId,
+        userId,
+        accountId,
+        providerMessageId: "shared",
+        direction: "incoming",
+        sender: { raw: "sender@example.test", email: "sender@example.test" },
+        internalDate: new Date(),
+        sentAt: new Date(),
+      });
+      await database.insert(messageAttachments).values({
+        messageId,
+        userId,
+        accountId,
+        filename: "test.txt",
+        objectKey,
+      });
+    }
+    const deletedKeys: string[] = [];
+    const stoppedTokens: string[] = [];
+    const dependencies = {
+      database,
+      encryptionKey,
+      deleteObjects: async (objectKeys: string[]) => {
+        deletedKeys.push(...objectKeys);
+      },
+      stopWatch: async (accessToken: string) => {
+        stoppedTokens.push(accessToken);
+      },
+      getStopAccessToken: async (accountId: string) => `fresh-${accountId}`,
+    };
+    const firstCleanup = await disconnect(first.id, userA);
+    await runGmailConnectionCleanup(firstCleanup, dependencies);
+    assert.deepEqual(stoppedTokens, []);
+    assert.deepEqual(deletedKeys, [keys.get(first.id)]);
+    assert.equal(
+      (
+        await database
+          .select()
+          .from(connectedAccounts)
+          .where(eq(connectedAccounts.id, first.id))
+      ).length,
+      0,
+    );
+    assert.equal(
+      (
+        await database
+          .select()
+          .from(messages)
+          .where(eq(messages.accountId, second.id))
+      ).length,
+      1,
+    );
+    assert.equal(
+      (
+        await database
+          .select()
+          .from(accountSecrets)
+          .where(eq(accountSecrets.accountId, second.id))
+      ).length,
+      1,
+    );
+    assert.equal(
+      (
+        await database
+          .select()
+          .from(gmailWatchStates)
+          .where(eq(gmailWatchStates.accountId, second.id))
+      )[0]?.status,
+      "active",
+    );
+    assert.deepEqual(
+      await runGmailConnectionCleanup(firstCleanup, dependencies),
+      { status: "inactive" },
+    );
+    await runGmailConnectionCleanup(
+      await disconnect(second.id, userB),
+      dependencies,
+    );
+    assert.deepEqual(stoppedTokens, [`fresh-${second.id}`]);
+    assert.deepEqual(deletedKeys, [keys.get(first.id), keys.get(second.id)]);
+  },
+);
+
+test(
+  "a sibling needing reauthorization still prevents watch stop",
+  { skip: !testDatabaseUrl },
+  async (t) => {
+    const { database, userA, userB, first, authentication, disconnect } =
+      await setup(t);
+    const second = await saveNewGmailConnection(
+      authentication(userB),
+      database,
+    );
+    await database
+      .update(connectedAccounts)
+      .set({ status: "reconnect_required" })
+      .where(eq(connectedAccounts.id, second.id));
+    await runGmailConnectionCleanup(await disconnect(first.id, userA), {
+      database,
+      encryptionKey,
+      deleteObjects: async () => {},
+      stopWatch: async () => {
+        assert.fail("a remaining connection still needs this watch");
+      },
+    });
+  },
+);
+
+test(
+  "watch renewal and disconnect serialize, and stale renewal never starts a disconnected watch",
+  { skip: !testDatabaseUrl },
+  async (t) => {
+    const { database, userA, first, providerAccountId, disconnect } =
+      await setup(t);
+    const entered = createBarrier();
+    const release = createBarrier();
+    const calls: string[] = [];
+    const renewal = renewGmailConnectionWatch(
+      {
+        accountId: first.id,
+        accessToken: `access-${userA}`,
+        topicName: "projects/test/topics/gmail",
+      },
+      {
+        database,
+        startWatch: async (token) => {
+          assert.equal(token, `access-${userA}`);
+          calls.push("watch");
+          entered.resolve();
+          await release.promise;
+          return {
+            historyId: "200",
+            expiration: String(new Date("2030-01-09").getTime()),
+          };
+        },
+      },
+    );
+    await entered.promise;
+    try {
+      const lock = await database.execute<{ locked: boolean }>(
+        sql`select pg_try_advisory_xact_lock(hashtextextended(${`invook:gmail-identity:${providerAccountId}`}, 0)) as locked`,
+      );
+      assert.equal(lock[0]?.locked, false);
+      const disconnection = disconnect(first.id, userA);
+      release.resolve();
+      await renewal;
+      await disconnection;
+    } finally {
+      release.resolve();
+      await renewal;
+    }
+    await assert.rejects(
+      renewGmailConnectionWatch(
+        {
+          accountId: first.id,
+          accessToken: "stale",
+          topicName: "projects/test/topics/gmail",
+        },
+        {
+          database,
+          startWatch: async () => {
+            assert.fail("must not restart after disconnect");
+          },
+        },
+      ),
+      GmailConnectionInactiveError,
+    );
+    assert.deepEqual(calls, ["watch"]);
+  },
+);
+
+test(
+  "last cleanup holds the identity lock through stop, object deletion, and account removal before reconnect",
+  { skip: !testDatabaseUrl },
+  async (t) => {
+    const {
+      database,
+      userA,
+      first,
+      providerAccountId,
+      authentication,
+      disconnect,
+    } = await setup(t);
+    const cleanupInput = await disconnect(first.id, userA);
+    const entered = createBarrier();
+    const release = createBarrier();
+    const order: string[] = [];
+    const cleanup = runGmailConnectionCleanup(cleanupInput, {
+      database,
+      encryptionKey,
+      stopWatch: async () => {
+        order.push("stop");
+        entered.resolve();
+        await release.promise;
+      },
+      deleteObjects: async () => {
+        order.push("delete-objects");
+      },
+    });
+    await entered.promise;
+    try {
+      const lock = await database.execute<{ locked: boolean }>(
+        sql`select pg_try_advisory_xact_lock(hashtextextended(${`invook:gmail-identity:${providerAccountId}`}, 0)) as locked`,
+      );
+      assert.equal(lock[0]?.locked, false);
+      // Models the callback's watch + save transaction while the previous grant
+      // is being cleaned. It must see deletion, not revive the old connection ID.
+      const reconnect = withGmailIdentityLock(
+        providerAccountId,
+        async (transaction) => {
+          order.push("new-watch");
+          return saveNewGmailConnection(authentication(userA), transaction);
+        },
+        database,
+      );
+      release.resolve();
+      await cleanup;
+      const replacement = await reconnect;
+      assert.equal(replacement.created, true);
+      assert.notEqual(replacement.id, first.id);
+      assert.deepEqual(order, ["stop", "delete-objects", "new-watch"]);
+      await runGmailConnectionCleanup(cleanupInput, {
+        database,
+        encryptionKey,
+        deleteObjects: async () => {
+          assert.fail("stale cleanup");
+        },
+        stopWatch: async () => {
+          assert.fail("stale cleanup");
+        },
+      });
+      assert.equal(
+        (
+          await database
+            .select()
+            .from(connectedAccounts)
+            .where(eq(connectedAccounts.id, replacement.id))
+        )[0]?.status,
+        "connected",
+      );
+    } finally {
+      release.resolve();
+      await cleanup;
+    }
+  },
+);
+
+test(
+  "provider stop failure leaves durable cleanup retryable and never deletes local data prematurely",
+  { skip: !testDatabaseUrl },
+  async (t) => {
+    const { database, userA, first, disconnect } = await setup(t);
+    const cleanupInput = await disconnect(first.id, userA);
+    await assert.rejects(
+      runGmailConnectionCleanup(cleanupInput, {
+        database,
+        encryptionKey,
+        stopWatch: async () => {
+          throw new Error("retryable transport failure");
+        },
+        deleteObjects: async () => {
+          assert.fail("stop has not succeeded");
+        },
+      }),
+      /retryable transport failure/,
+    );
+    assert.equal(
+      (
+        await database
+          .select()
+          .from(connectedAccounts)
+          .where(eq(connectedAccounts.id, first.id))
+      )[0]?.status,
+      "disconnected",
+    );
+    await runGmailConnectionCleanup(cleanupInput, {
+      database,
+      encryptionKey,
+      stopWatch: async () => {},
+      deleteObjects: async () => {},
+    });
+    assert.equal(
+      (
+        await database
+          .select()
+          .from(connectedAccounts)
+          .where(eq(connectedAccounts.id, first.id))
+      ).length,
+      0,
+    );
+  },
+);

--- a/apps/worker/src/gmail-watch-lifecycle.ts
+++ b/apps/worker/src/gmail-watch-lifecycle.ts
@@ -1,0 +1,150 @@
+import {
+  completeWorkflowStep,
+  decryptGoogleCredential,
+  getDatabase,
+  getGmailIdentityConnection,
+  getWorkerAccount,
+  hasOtherGmailConnections,
+  listGmailObjectKeysForAccount,
+  markGmailAccountCleanupRunning,
+  saveGmailWatchState,
+  withGmailIdentityLock,
+  type DatabaseExecutor,
+} from "@invook/database";
+import { GmailApiError, startGmailWatch, stopGmailWatch } from "@invook/gmail";
+
+export class GmailConnectionInactiveError extends Error {
+  constructor() {
+    super("The Gmail connection is inactive.");
+    this.name = "GmailConnectionInactiveError";
+  }
+}
+
+export async function renewGmailConnectionWatch(
+  input: { accountId: string; accessToken: string; topicName: string },
+  dependencies: {
+    database?: DatabaseExecutor;
+    startWatch?: typeof startGmailWatch;
+  } = {},
+): Promise<{ historyId: string; expirationAt: Date; renewedAt: Date }> {
+  const database = dependencies.database ?? getDatabase();
+  const identity = await getGmailIdentityConnection(input.accountId, database);
+  if (!identity) throw new GmailConnectionInactiveError();
+  return withGmailIdentityLock(
+    identity.providerAccountId,
+    async (transaction) => {
+      const account = await getGmailIdentityConnection(
+        input.accountId,
+        transaction,
+      );
+      if (account?.status !== "connected")
+        throw new GmailConnectionInactiveError();
+      const watch = await (dependencies.startWatch ?? startGmailWatch)(
+        input.accessToken,
+        {
+          topicName: input.topicName,
+        },
+      );
+      const expirationAt = new Date(Number(watch.expiration));
+      if (!Number.isFinite(expirationAt.getTime())) {
+        throw new Error("Gmail returned an invalid watch expiration.");
+      }
+      const renewedAt = new Date();
+      await saveGmailWatchState(
+        {
+          accountId: account.id,
+          watch: {
+            topicName: input.topicName,
+            historyId: watch.historyId,
+            expirationAt,
+          },
+          renewedAt,
+        },
+        transaction,
+      );
+      return { historyId: watch.historyId, expirationAt, renewedAt };
+    },
+    database,
+  );
+}
+
+export async function runGmailConnectionCleanup(
+  input: {
+    accountId: string;
+    userId: string;
+    cleanupId: string;
+    stepId: string;
+  },
+  dependencies: {
+    encryptionKey: string;
+    deleteObjects: (keys: string[]) => Promise<void>;
+    getStopAccessToken?: (
+      accountId: string,
+      database: DatabaseExecutor,
+    ) => Promise<string>;
+    database?: DatabaseExecutor;
+    stopWatch?: typeof stopGmailWatch;
+  },
+): Promise<{ objectCount: number } | { status: "inactive" }> {
+  const database = dependencies.database ?? getDatabase();
+  const identity = await getGmailIdentityConnection(input.accountId, database);
+  if (!identity) return { status: "inactive" };
+  return withGmailIdentityLock(
+    identity.providerAccountId,
+    async (transaction) => {
+      const current = await getGmailIdentityConnection(
+        input.accountId,
+        transaction,
+      );
+      if (
+        current?.userId !== input.userId ||
+        current.status !== "disconnected"
+      ) {
+        return { status: "inactive" };
+      }
+      await markGmailAccountCleanupRunning(input.cleanupId, transaction);
+      const hasOtherConnections = await hasOtherGmailConnections(
+        {
+          accountId: input.accountId,
+          providerAccountId: identity.providerAccountId,
+        },
+        transaction,
+      );
+      if (!hasOtherConnections) {
+        const account = await getWorkerAccount(input.accountId, transaction);
+        if (account) {
+          const accessToken = dependencies.getStopAccessToken
+            ? await dependencies.getStopAccessToken(
+                input.accountId,
+                transaction,
+              )
+            : decryptGoogleCredential(
+                account.tokenCiphertext,
+                dependencies.encryptionKey,
+              ).accessToken;
+          try {
+            await (dependencies.stopWatch ?? stopGmailWatch)(accessToken);
+          } catch (error) {
+            if (
+              !(error instanceof GmailApiError) ||
+              ![400, 401, 403, 404].includes(error.status)
+            ) {
+              throw error;
+            }
+          }
+        }
+      }
+      const objectKeys = await listGmailObjectKeysForAccount(
+        input.accountId,
+        transaction,
+      );
+      await dependencies.deleteObjects(objectKeys);
+      const result = { objectCount: objectKeys.length };
+      // Completion removes this connection and its cascaded local data. It must
+      // commit under the same identity lock as stop, not after reconnect can run.
+      await completeWorkflowStep(input.stepId, result, transaction);
+      return result;
+    },
+    database,
+  );
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -66,8 +66,6 @@ import {
   hasCompletedMailSyncPage,
   listenForTemporalCommandNotifications,
   listActiveTemporalTenantIds,
-  listGmailObjectKeysForAccount,
-  markGmailAccountCleanupRunning,
   listSubmittedThreadLabelBatchIds,
   markGmailReplicaReady,
   markMailSyncThreadRunning,
@@ -75,7 +73,6 @@ import {
   MEMORY_SCHEMA_VERSION,
   markDraftFeedbackAnalyzed,
   saveExtractedMemories,
-  saveGmailWatchState,
   saveGmailDraftResource,
   deleteGmailDraftResourceByMessageId,
   setGmailReplicaState,
@@ -93,6 +90,7 @@ import {
   upsertMailboxThreadMessages,
   withGmailAccountControlLock,
   type GoogleCredential,
+  type DatabaseExecutor,
   type IndexedMessage,
   type MemoryType,
   type WorkflowStepJob,
@@ -116,8 +114,6 @@ import {
   normalizeGmailFullMessage,
   parseGmailMessage,
   refreshGoogleAccessToken,
-  startGmailWatch,
-  stopGmailWatch,
   type ParsedGmailMessage,
 } from "@invook/gmail";
 import { createObjectStorage } from "@invook/object-storage";
@@ -131,6 +127,11 @@ import {
   TemporalRuntime,
 } from "./temporal-runtime";
 import { classifyGmailWorkflowFailure } from "./gmail-workflow-failure";
+import {
+  GmailConnectionInactiveError,
+  renewGmailConnectionWatch,
+  runGmailConnectionCleanup,
+} from "./gmail-watch-lifecycle";
 import {
   parseGmailThreadBatchPayload,
   processGmailThreadBatch,
@@ -210,6 +211,7 @@ function normalizedEmails(values: string[], ownerEmail: string): string[] {
 async function refreshCredentialIfRequired(
   accountId: string,
   credential: GoogleCredential,
+  database?: DatabaseExecutor,
 ): Promise<GoogleCredential> {
   const expiresSoon =
     Date.parse(credential.expiresAt) <= Date.now() + credentialRenewalWindowMs;
@@ -236,6 +238,7 @@ async function refreshCredentialIfRequired(
   await updateStoredCredential(
     accountId,
     encryptGoogleCredential(nextCredential, encryptionKey),
+    database,
   );
 
   return nextCredential;
@@ -660,13 +663,17 @@ async function applyHistoryRange(options: {
   return { ...applied, historyId };
 }
 
-async function getMailSyncContext(accountId: string) {
-  const account = await getWorkerAccount(accountId);
+async function getMailSyncContext(accountId: string, database?: DatabaseExecutor) {
+  const account = await getWorkerAccount(accountId, database);
   if (!account) {
     throw new Error("The connected Gmail account or credential was not found.");
   }
   const storedCredential = decryptGoogleCredential(account.tokenCiphertext, encryptionKey);
-  const credential = await refreshCredentialIfRequired(accountId, storedCredential);
+  const credential = await refreshCredentialIfRequired(
+    accountId,
+    storedCredential,
+    database,
+  );
   return { account, credential };
 }
 
@@ -938,24 +945,9 @@ function gmailPubSubTopic(): string {
 }
 
 async function renewGmailWatch(accountId: string, accessToken: string) {
-  const topicName = gmailPubSubTopic();
-  const watch = await startGmailWatch(accessToken, { topicName });
-  const expiration = Number(watch.expiration);
-  if (!Number.isFinite(expiration)) {
-    throw new Error("Gmail returned an invalid watch expiration.");
-  }
-  const renewedAt = new Date();
-  const expirationAt = new Date(expiration);
-  await saveGmailWatchState({
-    accountId,
-    watch: {
-      topicName,
-      historyId: watch.historyId,
-      expirationAt,
-    },
-    renewedAt,
+  return renewGmailConnectionWatch({
+    accountId, accessToken, topicName: gmailPubSubTopic(),
   });
-  return { historyId: watch.historyId, expirationAt, renewedAt };
 }
 
 async function ensureGmailWatch(accountId: string, accessToken: string) {
@@ -1219,26 +1211,16 @@ async function runGmailWatchRenewal(job: WorkflowStepJob) {
 }
 
 async function runGmailAccountCleanup(job: WorkflowStepJob) {
-  if (!job.accountId) throw new Error("The Gmail cleanup has no account.");
+  if (!job.accountId || !job.userId) throw new Error("The Gmail cleanup has no account owner.");
   const cleanupId = requiredString(job.payload.cleanupId, "Gmail cleanup ID");
-  await markGmailAccountCleanupRunning(cleanupId);
-  const account = await getWorkerAccount(job.accountId);
-  if (account) {
-    const credential = decryptGoogleCredential(account.tokenCiphertext, encryptionKey);
-    try {
-      await stopGmailWatch(credential.accessToken);
-    } catch (error) {
-      if (
-        !(error instanceof GmailApiError) ||
-        ![400, 401, 403, 404].includes(error.status)
-      ) {
-        throw error;
-      }
-    }
-  }
-  const objectKeys = await listGmailObjectKeysForAccount(job.accountId);
-  await objectStorage.deleteObjects(objectKeys);
-  return { objectCount: objectKeys.length };
+  return runGmailConnectionCleanup({
+    accountId: job.accountId, userId: job.userId, cleanupId, stepId: job.id,
+  }, {
+    encryptionKey,
+    deleteObjects: (keys) => objectStorage.deleteObjects(keys),
+    getStopAccessToken: async (accountId, database) =>
+      (await getMailSyncContext(accountId, database)).credential.accessToken,
+  });
 }
 
 async function runGmailObjectDelete(job: WorkflowStepJob) {
@@ -2064,6 +2046,11 @@ export async function runWorkflowStepActivity(
     await completeWorkflowStep(job.id, result);
     return { result };
   } catch (error) {
+    if (error instanceof GmailConnectionInactiveError) {
+      const result = { status: "inactive" };
+      await completeWorkflowStep(job.id, result);
+      return { result };
+    }
     const failure = classifyGmailWorkflowFailure(error, {
       attempt: job.attempts,
       maxAttempts: job.maxAttempts,

--- a/packages/database/drizzle/0038_shared_gmail_connections.sql
+++ b/packages/database/drizzle/0038_shared_gmail_connections.sql
@@ -1,0 +1,4 @@
+DROP INDEX "connected_accounts_provider_identity_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "connected_accounts_user_provider_identity_idx" ON "connected_accounts" USING btree ("user_id","provider","provider_account_id");--> statement-breakpoint
+CREATE INDEX "connected_accounts_active_email_idx" ON "connected_accounts" USING btree (lower("email")) WHERE "connected_accounts"."status" = 'connected';--> statement-breakpoint
+CREATE INDEX "connected_accounts_provider_identity_idx" ON "connected_accounts" USING btree ("provider","provider_account_id");

--- a/packages/database/drizzle/meta/0038_snapshot.json
+++ b/packages/database/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,5355 @@
+{
+  "id": "a34a80f1-faee-4e32-9844-5d397332488a",
+  "prevId": "d19a6cc3-b76e-4d6f-a4e2-c75a86e5e698",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_secrets": {
+      "name": "account_secrets",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "refreshed_at": {
+          "name": "refreshed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_secrets_account_id_connected_accounts_id_fk": {
+          "name": "account_secrets_account_id_connected_accounts_id_fk",
+          "tableFrom": "account_secrets",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_accounts": {
+      "name": "auth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_accounts_provider_identity_idx": {
+          "name": "auth_accounts_provider_identity_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_accounts_user_idx": {
+          "name": "auth_accounts_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_accounts_user_id_profiles_id_fk": {
+          "name": "auth_accounts_user_id_profiles_id_fk",
+          "tableFrom": "auth_accounts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "auth_sessions_token_idx": {
+          "name": "auth_sessions_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_user_idx": {
+          "name": "auth_sessions_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_expiration_idx": {
+          "name": "auth_sessions_expiration_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_user_id_profiles_id_fk": {
+          "name": "auth_sessions_user_id_profiles_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verifications": {
+      "name": "auth_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_verifications_identifier_idx": {
+          "name": "auth_verifications_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connected_accounts": {
+      "name": "connected_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gmail'"
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "memory_acknowledged_at": {
+          "name": "memory_acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_state": {
+          "name": "sync_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"mailSync\":\"pending\",\"memory\":\"pending\"}'::jsonb"
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connected_accounts_user_provider_identity_idx": {
+          "name": "connected_accounts_user_provider_identity_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connected_accounts_provider_identity_idx": {
+          "name": "connected_accounts_provider_identity_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connected_accounts_active_email_idx": {
+          "name": "connected_accounts_active_email_idx",
+          "columns": [
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connected_accounts\".\"status\" = 'connected'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connected_accounts_user_created_idx": {
+          "name": "connected_accounts_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connected_accounts_active_user_idx": {
+          "name": "connected_accounts_active_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"connected_accounts\".\"status\" <> 'disconnected'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connected_accounts_user_id_profiles_id_fk": {
+          "name": "connected_accounts_user_id_profiles_id_fk",
+          "tableFrom": "connected_accounts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connected_accounts_provider_check": {
+          "name": "connected_accounts_provider_check",
+          "value": "\"connected_accounts\".\"provider\" = 'gmail'"
+        },
+        "connected_accounts_status_check": {
+          "name": "connected_accounts_status_check",
+          "value": "\"connected_accounts\".\"status\" in ('connected', 'reconnect_required', 'disconnected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invook'"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_draft_id": {
+          "name": "provider_draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_history_id": {
+          "name": "provider_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'editing'"
+        },
+        "generated_text": {
+          "name": "generated_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_text": {
+          "name": "current_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "final_sent_text": {
+          "name": "final_sent_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_memory_ids": {
+          "name": "used_memory_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::uuid[]"
+        },
+        "generation_metadata": {
+          "name": "generation_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "edit_signals": {
+          "name": "edit_signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "feedback_version": {
+          "name": "feedback_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_feedback_at": {
+          "name": "last_feedback_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drafts_user_updated_idx": {
+          "name": "drafts_user_updated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_account_provider_idx": {
+          "name": "drafts_account_provider_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"drafts\".\"provider_draft_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drafts_account_provider_thread_idx": {
+          "name": "drafts_account_provider_thread_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drafts_user_id_profiles_id_fk": {
+          "name": "drafts_user_id_profiles_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_account_id_connected_accounts_id_fk": {
+          "name": "drafts_account_id_connected_accounts_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_thread_id_threads_id_fk": {
+          "name": "drafts_thread_id_threads_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drafts_message_id_messages_id_fk": {
+          "name": "drafts_message_id_messages_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "drafts_kind_check": {
+          "name": "drafts_kind_check",
+          "value": "\"drafts\".\"kind\" in ('gmail', 'invook')"
+        },
+        "drafts_kind_contract_check": {
+          "name": "drafts_kind_contract_check",
+          "value": "(\"drafts\".\"kind\" = 'gmail' and \"drafts\".\"provider_draft_id\" is not null and \"drafts\".\"provider_thread_id\" is not null) or (\"drafts\".\"kind\" = 'invook' and \"drafts\".\"thread_id\" is not null and \"drafts\".\"provider_draft_id\" is null and \"drafts\".\"provider_message_id\" is null and \"drafts\".\"provider_thread_id\" is null and \"drafts\".\"provider_history_id\" is null)"
+        },
+        "drafts_status_check": {
+          "name": "drafts_status_check",
+          "value": "\"drafts\".\"status\" in ('editing', 'sent', 'discarded', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_account_cleanups": {
+      "name": "gmail_account_cleanups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "object_count": {
+          "name": "object_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_account_cleanups_account_idx": {
+          "name": "gmail_account_cleanups_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_account_cleanups_user_created_idx": {
+          "name": "gmail_account_cleanups_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_account_cleanups_user_id_profiles_id_fk": {
+          "name": "gmail_account_cleanups_user_id_profiles_id_fk",
+          "tableFrom": "gmail_account_cleanups",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_account_cleanups_status_check": {
+          "name": "gmail_account_cleanups_status_check",
+          "value": "\"gmail_account_cleanups\".\"status\" in ('queued', 'running', 'complete', 'failed')"
+        },
+        "gmail_account_cleanups_object_count_check": {
+          "name": "gmail_account_cleanups_object_count_check",
+          "value": "\"gmail_account_cleanups\".\"object_count\" is null or \"gmail_account_cleanups\".\"object_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_connection_requests": {
+      "name": "gmail_connection_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state_hash": {
+          "name": "state_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_connection_requests_state_idx": {
+          "name": "gmail_connection_requests_state_idx",
+          "columns": [
+            {
+              "expression": "state_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connection_requests_expiration_idx": {
+          "name": "gmail_connection_requests_expiration_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_connection_requests_user_idx": {
+          "name": "gmail_connection_requests_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_connection_requests_user_id_profiles_id_fk": {
+          "name": "gmail_connection_requests_user_id_profiles_id_fk",
+          "tableFrom": "gmail_connection_requests",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_connection_requests_account_id_connected_accounts_id_fk": {
+          "name": "gmail_connection_requests_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_connection_requests",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gmail_draft_write_operations": {
+      "name": "gmail_draft_write_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_fingerprint": {
+          "name": "request_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_draft_id": {
+          "name": "provider_draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_draft_write_operations_user_key_idx": {
+          "name": "gmail_draft_write_operations_user_key_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_draft_write_operations_account_status_idx": {
+          "name": "gmail_draft_write_operations_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_draft_write_operations_user_id_profiles_id_fk": {
+          "name": "gmail_draft_write_operations_user_id_profiles_id_fk",
+          "tableFrom": "gmail_draft_write_operations",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gmail_draft_write_operations_account_id_connected_accounts_id_fk": {
+          "name": "gmail_draft_write_operations_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_draft_write_operations",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_draft_write_operations_operation_check": {
+          "name": "gmail_draft_write_operations_operation_check",
+          "value": "\"gmail_draft_write_operations\".\"operation\" in ('create', 'update', 'send')"
+        },
+        "gmail_draft_write_operations_status_check": {
+          "name": "gmail_draft_write_operations_status_check",
+          "value": "\"gmail_draft_write_operations\".\"status\" in ('pending', 'complete')"
+        },
+        "gmail_draft_write_operations_result_check": {
+          "name": "gmail_draft_write_operations_result_check",
+          "value": "(\"gmail_draft_write_operations\".\"status\" = 'pending' and \"gmail_draft_write_operations\".\"completed_at\" is null and ((\"gmail_draft_write_operations\".\"provider_draft_id\" is null and \"gmail_draft_write_operations\".\"provider_message_id\" is null and \"gmail_draft_write_operations\".\"provider_thread_id\" is null) or (\"gmail_draft_write_operations\".\"provider_draft_id\" is not null and \"gmail_draft_write_operations\".\"provider_message_id\" is not null and \"gmail_draft_write_operations\".\"provider_thread_id\" is not null))) or (\"gmail_draft_write_operations\".\"status\" = 'complete' and \"gmail_draft_write_operations\".\"provider_draft_id\" is not null and \"gmail_draft_write_operations\".\"provider_message_id\" is not null and \"gmail_draft_write_operations\".\"provider_thread_id\" is not null and \"gmail_draft_write_operations\".\"completed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_replica_states": {
+      "name": "gmail_replica_states",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "initial_history_id": {
+          "name": "initial_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_cursor": {
+          "name": "history_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_history_cursor": {
+          "name": "pending_history_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_history_at": {
+          "name": "last_history_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_replica_states_state_idx": {
+          "name": "gmail_replica_states_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_replica_states_account_id_connected_accounts_id_fk": {
+          "name": "gmail_replica_states_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_replica_states",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_replica_states_state_check": {
+          "name": "gmail_replica_states_state_check",
+          "value": "\"gmail_replica_states\".\"state\" in ('pending', 'snapshotting', 'replaying', 'ready', 'repairing', 'failed', 'deleting')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_sync_items": {
+      "name": "gmail_sync_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_sync_items_run_thread_idx": {
+          "name": "gmail_sync_items_run_thread_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "gmail_sync_items_run_status_idx": {
+          "name": "gmail_sync_items_run_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_sync_items_run_id_mail_sync_runs_id_fk": {
+          "name": "gmail_sync_items_run_id_mail_sync_runs_id_fk",
+          "tableFrom": "gmail_sync_items",
+          "tableTo": "mail_sync_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_sync_items_status_check": {
+          "name": "gmail_sync_items_status_check",
+          "value": "\"gmail_sync_items\".\"status\" in ('queued', 'running', 'complete', 'failed')"
+        },
+        "gmail_sync_items_attempts_check": {
+          "name": "gmail_sync_items_attempts_check",
+          "value": "\"gmail_sync_items\".\"attempts\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_sync_pages": {
+      "name": "gmail_sync_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_number": {
+          "name": "page_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_token": {
+          "name": "page_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_page_token": {
+          "name": "next_page_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovered_thread_count": {
+          "name": "discovered_thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_sync_pages_run_number_idx": {
+          "name": "gmail_sync_pages_run_number_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "page_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_sync_pages_run_id_mail_sync_runs_id_fk": {
+          "name": "gmail_sync_pages_run_id_mail_sync_runs_id_fk",
+          "tableFrom": "gmail_sync_pages",
+          "tableTo": "mail_sync_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_sync_pages_number_check": {
+          "name": "gmail_sync_pages_number_check",
+          "value": "\"gmail_sync_pages\".\"page_number\" > 0"
+        },
+        "gmail_sync_pages_thread_count_check": {
+          "name": "gmail_sync_pages_thread_count_check",
+          "value": "\"gmail_sync_pages\".\"discovered_thread_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.gmail_watch_states": {
+      "name": "gmail_watch_states",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "topic_name": {
+          "name": "topic_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "history_id": {
+          "name": "history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration_at": {
+          "name": "expiration_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_renewed_at": {
+          "name": "last_renewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gmail_watch_states_expiration_idx": {
+          "name": "gmail_watch_states_expiration_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expiration_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "gmail_watch_states_account_id_connected_accounts_id_fk": {
+          "name": "gmail_watch_states_account_id_connected_accounts_id_fk",
+          "tableFrom": "gmail_watch_states",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "gmail_watch_states_status_check": {
+          "name": "gmail_watch_states_status_check",
+          "value": "\"gmail_watch_states\".\"status\" in ('active', 'stopped', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.historical_thread_label_scans": {
+      "name": "historical_thread_label_scans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enablement_version": {
+          "name": "enablement_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "after": {
+          "name": "after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "before": {
+          "name": "before",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_receipt_id": {
+          "name": "preview_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursor_thread_id": {
+          "name": "cursor_thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "historical_thread_label_scans_account_status_idx": {
+          "name": "historical_thread_label_scans_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "historical_thread_label_scans_user_id_profiles_id_fk": {
+          "name": "historical_thread_label_scans_user_id_profiles_id_fk",
+          "tableFrom": "historical_thread_label_scans",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "historical_thread_label_scans_account_id_connected_accounts_id_fk": {
+          "name": "historical_thread_label_scans_account_id_connected_accounts_id_fk",
+          "tableFrom": "historical_thread_label_scans",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "historical_thread_label_scans_label_id_labels_id_fk": {
+          "name": "historical_thread_label_scans_label_id_labels_id_fk",
+          "tableFrom": "historical_thread_label_scans",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "historical_thread_label_scans_preview_receipt_id_label_preview_receipts_id_fk": {
+          "name": "historical_thread_label_scans_preview_receipt_id_label_preview_receipts_id_fk",
+          "tableFrom": "historical_thread_label_scans",
+          "tableTo": "label_preview_receipts",
+          "columnsFrom": [
+            "preview_receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "historical_thread_label_scans_status_check": {
+          "name": "historical_thread_label_scans_status_check",
+          "value": "\"historical_thread_label_scans\".\"status\" in ('queued', 'running', 'complete', 'failed', 'superseded')"
+        },
+        "historical_thread_label_scans_window_check": {
+          "name": "historical_thread_label_scans_window_check",
+          "value": "\"historical_thread_label_scans\".\"after\" <= \"historical_thread_label_scans\".\"before\""
+        },
+        "historical_thread_label_scans_versions_check": {
+          "name": "historical_thread_label_scans_versions_check",
+          "value": "\"historical_thread_label_scans\".\"definition_version\" > 0 and \"historical_thread_label_scans\".\"enablement_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.label_preview_receipts": {
+      "name": "label_preview_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_hash": {
+          "name": "definition_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scanned_thread_count": {
+          "name": "scanned_thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_scan_id": {
+          "name": "consumed_scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "label_preview_receipts_account_expiration_idx": {
+          "name": "label_preview_receipts_account_expiration_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "label_preview_receipts_consumed_scan_idx": {
+          "name": "label_preview_receipts_consumed_scan_idx",
+          "columns": [
+            {
+              "expression": "consumed_scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"label_preview_receipts\".\"consumed_scan_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "label_preview_receipts_user_id_profiles_id_fk": {
+          "name": "label_preview_receipts_user_id_profiles_id_fk",
+          "tableFrom": "label_preview_receipts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "label_preview_receipts_account_id_connected_accounts_id_fk": {
+          "name": "label_preview_receipts_account_id_connected_accounts_id_fk",
+          "tableFrom": "label_preview_receipts",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "label_preview_receipts_definition_hash_check": {
+          "name": "label_preview_receipts_definition_hash_check",
+          "value": "\"label_preview_receipts\".\"definition_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "label_preview_receipts_count_check": {
+          "name": "label_preview_receipts_count_check",
+          "value": "\"label_preview_receipts\".\"scanned_thread_count\" between 0 and 100"
+        },
+        "label_preview_receipts_results_check": {
+          "name": "label_preview_receipts_results_check",
+          "value": "jsonb_typeof(\"label_preview_receipts\".\"results\") = 'array' and jsonb_array_length(\"label_preview_receipts\".\"results\") = \"label_preview_receipts\".\"scanned_thread_count\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_label_id": {
+          "name": "provider_label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "system_key": {
+          "name": "system_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "enablement_version": {
+          "name": "enablement_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labels_account_provider_idx": {
+          "name": "labels_account_provider_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"labels\".\"provider_label_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_account_invook_name_idx": {
+          "name": "labels_account_invook_name_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"labels\".\"kind\" = 'invook'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_account_system_key_idx": {
+          "name": "labels_account_system_key_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "system_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"labels\".\"system_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_account_created_idx": {
+          "name": "labels_account_created_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "labels_account_kind_idx": {
+          "name": "labels_account_kind_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labels_user_id_profiles_id_fk": {
+          "name": "labels_user_id_profiles_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "labels_account_id_connected_accounts_id_fk": {
+          "name": "labels_account_id_connected_accounts_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "labels_kind_check": {
+          "name": "labels_kind_check",
+          "value": "\"labels\".\"kind\" in ('gmail', 'invook')"
+        },
+        "labels_name_check": {
+          "name": "labels_name_check",
+          "value": "char_length(btrim(\"labels\".\"name\")) > 0"
+        },
+        "labels_normalized_name_check": {
+          "name": "labels_normalized_name_check",
+          "value": "char_length(btrim(\"labels\".\"normalized_name\")) > 0"
+        },
+        "labels_kind_contract_check": {
+          "name": "labels_kind_contract_check",
+          "value": "(\"labels\".\"kind\" = 'gmail' and \"labels\".\"provider_label_id\" is not null and \"labels\".\"provider_type\" = 'system' and \"labels\".\"system_key\" is null) or (\"labels\".\"kind\" = 'invook' and \"labels\".\"provider_label_id\" is null and \"labels\".\"provider_type\" is null and char_length(btrim(\"labels\".\"description\")) > 0)"
+        },
+        "labels_gmail_mailbox_state_check": {
+          "name": "labels_gmail_mailbox_state_check",
+          "value": "\"labels\".\"kind\" <> 'gmail' or \"labels\".\"provider_label_id\" in ('INBOX', 'SENT', 'DRAFT', 'TRASH', 'SPAM', 'STARRED', 'UNREAD')"
+        },
+        "labels_system_key_check": {
+          "name": "labels_system_key_check",
+          "value": "\"labels\".\"system_key\" is null or \"labels\".\"system_key\" in ('important', 'newsletter', 'billing', 'others')"
+        },
+        "labels_enabled_contract_check": {
+          "name": "labels_enabled_contract_check",
+          "value": "\"labels\".\"is_enabled\" or \"labels\".\"system_key\" is distinct from 'others'"
+        },
+        "labels_definition_version_check": {
+          "name": "labels_definition_version_check",
+          "value": "\"labels\".\"definition_version\" > 0"
+        },
+        "labels_enablement_version_check": {
+          "name": "labels_enablement_version_check",
+          "value": "\"labels\".\"enablement_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mail_sync_runs": {
+      "name": "mail_sync_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_type": {
+          "name": "run_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'initial'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "starting_history_cursor": {
+          "name": "starting_history_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_history_cursor": {
+          "name": "final_history_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovery_complete": {
+          "name": "discovery_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "discovered_thread_count": {
+          "name": "discovered_thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_thread_count": {
+          "name": "processed_thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_thread_count": {
+          "name": "failed_thread_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mail_sync_runs_idempotency_key_idx": {
+          "name": "mail_sync_runs_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_sync_runs_single_active_account_idx": {
+          "name": "mail_sync_runs_single_active_account_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"mail_sync_runs\".\"status\" in ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mail_sync_runs_account_created_idx": {
+          "name": "mail_sync_runs_account_created_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mail_sync_runs_user_id_profiles_id_fk": {
+          "name": "mail_sync_runs_user_id_profiles_id_fk",
+          "tableFrom": "mail_sync_runs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mail_sync_runs_account_id_connected_accounts_id_fk": {
+          "name": "mail_sync_runs_account_id_connected_accounts_id_fk",
+          "tableFrom": "mail_sync_runs",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mail_sync_runs_status_check": {
+          "name": "mail_sync_runs_status_check",
+          "value": "\"mail_sync_runs\".\"status\" in ('queued', 'running', 'complete', 'failed', 'superseded')"
+        },
+        "mail_sync_runs_type_check": {
+          "name": "mail_sync_runs_type_check",
+          "value": "\"mail_sync_runs\".\"run_type\" in ('initial', 'repair')"
+        },
+        "mail_sync_runs_page_count_check": {
+          "name": "mail_sync_runs_page_count_check",
+          "value": "\"mail_sync_runs\".\"page_count\" >= 0"
+        },
+        "mail_sync_runs_thread_counts_check": {
+          "name": "mail_sync_runs_thread_counts_check",
+          "value": "\"mail_sync_runs\".\"discovered_thread_count\" >= 0 and \"mail_sync_runs\".\"processed_thread_count\" >= 0 and \"mail_sync_runs\".\"failed_thread_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mailbox_change_events": {
+      "name": "mailbox_change_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mailbox_change_events_account_created_idx": {
+          "name": "mailbox_change_events_account_created_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mailbox_change_events_user_id_profiles_id_fk": {
+          "name": "mailbox_change_events_user_id_profiles_id_fk",
+          "tableFrom": "mailbox_change_events",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mailbox_change_events_account_id_connected_accounts_id_fk": {
+          "name": "mailbox_change_events_account_id_connected_accounts_id_fk",
+          "tableFrom": "mailbox_change_events",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "mailbox_change_events_type_check": {
+          "name": "mailbox_change_events_type_check",
+          "value": "\"mailbox_change_events\".\"change_type\" in ('replica_ready', 'history_applied', 'drafts_changed', 'labels_changed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.memory_deletions": {
+      "name": "memory_deletions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_deletions_account_fingerprint_idx": {
+          "name": "memory_deletions_account_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_deletions_user_deleted_idx": {
+          "name": "memory_deletions_user_deleted_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_deletions_user_id_profiles_id_fk": {
+          "name": "memory_deletions_user_id_profiles_id_fk",
+          "tableFrom": "memory_deletions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_deletions_account_id_connected_accounts_id_fk": {
+          "name": "memory_deletions_account_id_connected_accounts_id_fk",
+          "tableFrom": "memory_deletions",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_deletions_type_check": {
+          "name": "memory_deletions_type_check",
+          "value": "\"memory_deletions\".\"memory_type\" in ('preference', 'contact', 'scheduling')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.memory_entries": {
+      "name": "memory_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "statement": {
+          "name": "statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evidence_message_ids": {
+          "name": "evidence_message_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::uuid[]"
+        },
+        "evidence_draft_ids": {
+          "name": "evidence_draft_ids",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::uuid[]"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_entries_account_fingerprint_idx": {
+          "name": "memory_entries_account_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_entries_account_type_contact_idx": {
+          "name": "memory_entries_account_type_contact_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_entries_user_id_profiles_id_fk": {
+          "name": "memory_entries_user_id_profiles_id_fk",
+          "tableFrom": "memory_entries",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_entries_account_id_connected_accounts_id_fk": {
+          "name": "memory_entries_account_id_connected_accounts_id_fk",
+          "tableFrom": "memory_entries",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_entries_type_check": {
+          "name": "memory_entries_type_check",
+          "value": "\"memory_entries\".\"memory_type\" in ('preference', 'contact', 'scheduling')"
+        },
+        "memory_entries_source_check": {
+          "name": "memory_entries_source_check",
+          "value": "\"memory_entries\".\"source\" in ('user', 'inferred', 'feedback')"
+        },
+        "memory_entries_contact_check": {
+          "name": "memory_entries_contact_check",
+          "value": "(\"memory_entries\".\"memory_type\" = 'contact' and \"memory_entries\".\"contact_email\" is not null) or (\"memory_entries\".\"memory_type\" <> 'contact' and \"memory_entries\".\"contact_email\" is null)"
+        },
+        "memory_entries_statement_check": {
+          "name": "memory_entries_statement_check",
+          "value": "char_length(\"memory_entries\".\"statement\") between 3 and 500"
+        },
+        "memory_entries_confidence_check": {
+          "name": "memory_entries_confidence_check",
+          "value": "\"memory_entries\".\"confidence\" is null or \"memory_entries\".\"confidence\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.memory_pending_evidence": {
+      "name": "memory_pending_evidence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "memory_pending_evidence_message_scope_idx": {
+          "name": "memory_pending_evidence_message_scope_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memory_pending_evidence_account_scope_idx": {
+          "name": "memory_pending_evidence_account_scope_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "schema_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memory_pending_evidence_user_id_profiles_id_fk": {
+          "name": "memory_pending_evidence_user_id_profiles_id_fk",
+          "tableFrom": "memory_pending_evidence",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_pending_evidence_account_id_connected_accounts_id_fk": {
+          "name": "memory_pending_evidence_account_id_connected_accounts_id_fk",
+          "tableFrom": "memory_pending_evidence",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_pending_evidence_thread_id_threads_id_fk": {
+          "name": "memory_pending_evidence_thread_id_threads_id_fk",
+          "tableFrom": "memory_pending_evidence",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memory_pending_evidence_message_id_messages_id_fk": {
+          "name": "memory_pending_evidence_message_id_messages_id_fk",
+          "tableFrom": "memory_pending_evidence",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memory_pending_evidence_scope_check": {
+          "name": "memory_pending_evidence_scope_check",
+          "value": "\"memory_pending_evidence\".\"scope\" in ('global', 'contact')"
+        },
+        "memory_pending_evidence_contact_check": {
+          "name": "memory_pending_evidence_contact_check",
+          "value": "(\"memory_pending_evidence\".\"scope\" = 'global' and \"memory_pending_evidence\".\"contact_email\" = '') or (\"memory_pending_evidence\".\"scope\" = 'contact' and char_length(btrim(\"memory_pending_evidence\".\"contact_email\")) > 0)"
+        },
+        "memory_pending_evidence_schema_version_check": {
+          "name": "memory_pending_evidence_schema_version_check",
+          "value": "\"memory_pending_evidence\".\"schema_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_attachments": {
+      "name": "message_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_attachment_id": {
+          "name": "provider_attachment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_part_path": {
+          "name": "mime_part_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename_search_document": {
+          "name": "filename_search_document",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', regexp_replace(filename, '[_\\.-]+', ' ', 'g'))",
+            "type": "stored"
+          }
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_disposition": {
+          "name": "content_disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_key": {
+          "name": "object_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum_sha256": {
+          "name": "checksum_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_length": {
+          "name": "content_length",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_attachments_message_idx": {
+          "name": "message_attachments_message_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_attachments_account_filename_idx": {
+          "name": "message_attachments_account_filename_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "filename",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_attachments_filename_search_idx": {
+          "name": "message_attachments_filename_search_idx",
+          "columns": [
+            {
+              "expression": "filename_search_document",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_attachments_user_id_profiles_id_fk": {
+          "name": "message_attachments_user_id_profiles_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_attachments_account_id_connected_accounts_id_fk": {
+          "name": "message_attachments_account_id_connected_accounts_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_attachments_message_id_messages_id_fk": {
+          "name": "message_attachments_message_id_messages_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "message_attachments_size_check": {
+          "name": "message_attachments_size_check",
+          "value": "\"message_attachments\".\"size\" is null or \"message_attachments\".\"size\" >= 0"
+        },
+        "message_attachments_content_length_check": {
+          "name": "message_attachments_content_length_check",
+          "value": "\"message_attachments\".\"content_length\" is null or \"message_attachments\".\"content_length\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_labels": {
+      "name": "message_labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_labels_message_label_idx": {
+          "name": "message_labels_message_label_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_labels_account_label_idx": {
+          "name": "message_labels_account_label_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_labels_user_id_profiles_id_fk": {
+          "name": "message_labels_user_id_profiles_id_fk",
+          "tableFrom": "message_labels",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_labels_account_id_connected_accounts_id_fk": {
+          "name": "message_labels_account_id_connected_accounts_id_fk",
+          "tableFrom": "message_labels",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_labels_message_id_messages_id_fk": {
+          "name": "message_labels_message_id_messages_id_fk",
+          "tableFrom": "message_labels",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_labels_label_id_labels_id_fk": {
+          "name": "message_labels_label_id_labels_id_fk",
+          "tableFrom": "message_labels",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "message_labels_source_check": {
+          "name": "message_labels_source_check",
+          "value": "\"message_labels\".\"source\" = 'gmail'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender": {
+          "name": "sender",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "provider_history_id": {
+          "name": "provider_history_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internal_date": {
+          "name": "internal_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_estimate": {
+          "name": "size_estimate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_lines": {
+          "name": "header_lines",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "body_text": {
+          "name": "body_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_memory_eligible": {
+          "name": "is_memory_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "excluded_from_memory": {
+          "name": "excluded_from_memory",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "search_document": {
+          "name": "search_document",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(subject, '') || ' ' || coalesce(body_text, ''))",
+            "type": "stored"
+          }
+        },
+        "metadata_search_document": {
+          "name": "metadata_search_document",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('simple', coalesce(sender->>'raw', '') || ' ' || coalesce(sender->>'email', '') || ' ' || coalesce(recipients::text, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_thread_provider_message_idx": {
+          "name": "messages_thread_provider_message_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_thread_sent_idx": {
+          "name": "messages_thread_sent_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_account_provider_idx": {
+          "name": "messages_account_provider_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_search_idx": {
+          "name": "messages_search_idx",
+          "columns": [
+            {
+              "expression": "search_document",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_metadata_search_idx": {
+          "name": "messages_metadata_search_idx",
+          "columns": [
+            {
+              "expression": "metadata_search_document",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_memory_eligible_idx": {
+          "name": "messages_memory_eligible_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"direction\" = 'outgoing' and \"messages\".\"is_memory_eligible\" and not \"messages\".\"excluded_from_memory\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_user_id_profiles_id_fk": {
+          "name": "messages_user_id_profiles_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_account_id_connected_accounts_id_fk": {
+          "name": "messages_account_id_connected_accounts_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_thread_id_threads_id_fk": {
+          "name": "messages_thread_id_threads_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messages_direction_check": {
+          "name": "messages_direction_check",
+          "value": "\"messages\".\"direction\" in ('incoming', 'outgoing')"
+        },
+        "messages_size_estimate_check": {
+          "name": "messages_size_estimate_check",
+          "value": "\"messages\".\"size_estimate\" is null or \"messages\".\"size_estimate\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_acknowledged_at": {
+          "name": "memory_acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "profiles_email_idx": {
+          "name": "profiles_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.temporal_commands": {
+      "name": "temporal_commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_step_id": {
+          "name": "workflow_step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_task_lane": {
+          "name": "activity_task_lane",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatch_attempts": {
+          "name": "dispatch_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "temporal_commands_workflow_step_idx": {
+          "name": "temporal_commands_workflow_step_idx",
+          "columns": [
+            {
+              "expression": "workflow_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temporal_commands_undispatched_idx": {
+          "name": "temporal_commands_undispatched_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"temporal_commands\".\"dispatched_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "temporal_commands_workflow_step_id_workflow_steps_id_fk": {
+          "name": "temporal_commands_workflow_step_id_workflow_steps_id_fk",
+          "tableFrom": "temporal_commands",
+          "tableTo": "workflow_steps",
+          "columnsFrom": [
+            "workflow_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "temporal_commands_dispatch_attempts_check": {
+          "name": "temporal_commands_dispatch_attempts_check",
+          "value": "\"temporal_commands\".\"dispatch_attempts\" >= 0"
+        },
+        "temporal_commands_activity_task_lane_check": {
+          "name": "temporal_commands_activity_task_lane_check",
+          "value": "\"temporal_commands\".\"activity_task_lane\" in ('control', 'live', 'bulk')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.thread_label_assignments": {
+      "name": "thread_label_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "definition_version": {
+          "name": "definition_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_version": {
+          "name": "assignment_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "thread_label_assignments_thread_idx": {
+          "name": "thread_label_assignments_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_label_assignments_account_label_idx": {
+          "name": "thread_label_assignments_account_label_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_label_assignments_user_id_profiles_id_fk": {
+          "name": "thread_label_assignments_user_id_profiles_id_fk",
+          "tableFrom": "thread_label_assignments",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_label_assignments_account_id_connected_accounts_id_fk": {
+          "name": "thread_label_assignments_account_id_connected_accounts_id_fk",
+          "tableFrom": "thread_label_assignments",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_label_assignments_thread_id_threads_id_fk": {
+          "name": "thread_label_assignments_thread_id_threads_id_fk",
+          "tableFrom": "thread_label_assignments",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_label_assignments_label_id_labels_id_fk": {
+          "name": "thread_label_assignments_label_id_labels_id_fk",
+          "tableFrom": "thread_label_assignments",
+          "tableTo": "labels",
+          "columnsFrom": [
+            "label_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "thread_label_assignments_source_check": {
+          "name": "thread_label_assignments_source_check",
+          "value": "\"thread_label_assignments\".\"source\" in ('ai', 'user')"
+        },
+        "thread_label_assignments_confidence_check": {
+          "name": "thread_label_assignments_confidence_check",
+          "value": "\"thread_label_assignments\".\"confidence\" is null or \"thread_label_assignments\".\"confidence\" between 0 and 100"
+        },
+        "thread_label_assignments_definition_version_check": {
+          "name": "thread_label_assignments_definition_version_check",
+          "value": "\"thread_label_assignments\".\"definition_version\" > 0"
+        },
+        "thread_label_assignments_assignment_version_check": {
+          "name": "thread_label_assignments_assignment_version_check",
+          "value": "\"thread_label_assignments\".\"assignment_version\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.thread_label_batch_submissions": {
+      "name": "thread_label_batch_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_step_id": {
+          "name": "workflow_step_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai'"
+        },
+        "provider_batch_id": {
+          "name": "provider_batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_file_id": {
+          "name": "input_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_file_id": {
+          "name": "output_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_file_id": {
+          "name": "error_file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition_hash": {
+          "name": "definition_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "historical_scan_id": {
+          "name": "historical_scan_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_attempt": {
+          "name": "retry_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "continuations": {
+          "name": "continuations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'preparing'"
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "thread_label_batch_submissions_workflow_step_idx": {
+          "name": "thread_label_batch_submissions_workflow_step_idx",
+          "columns": [
+            {
+              "expression": "workflow_step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_label_batch_submissions_provider_batch_idx": {
+          "name": "thread_label_batch_submissions_provider_batch_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"thread_label_batch_submissions\".\"provider_batch_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_label_batch_submissions_scan_active_idx": {
+          "name": "thread_label_batch_submissions_scan_active_idx",
+          "columns": [
+            {
+              "expression": "historical_scan_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"thread_label_batch_submissions\".\"status\" in ('preparing', 'submitted')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "thread_label_batch_submissions_account_status_idx": {
+          "name": "thread_label_batch_submissions_account_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "thread_label_batch_submissions_workflow_step_id_workflow_steps_id_fk": {
+          "name": "thread_label_batch_submissions_workflow_step_id_workflow_steps_id_fk",
+          "tableFrom": "thread_label_batch_submissions",
+          "tableTo": "workflow_steps",
+          "columnsFrom": [
+            "workflow_step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_label_batch_submissions_user_id_profiles_id_fk": {
+          "name": "thread_label_batch_submissions_user_id_profiles_id_fk",
+          "tableFrom": "thread_label_batch_submissions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_label_batch_submissions_account_id_connected_accounts_id_fk": {
+          "name": "thread_label_batch_submissions_account_id_connected_accounts_id_fk",
+          "tableFrom": "thread_label_batch_submissions",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "thread_label_batch_submissions_historical_scan_id_historical_thread_label_scans_id_fk": {
+          "name": "thread_label_batch_submissions_historical_scan_id_historical_thread_label_scans_id_fk",
+          "tableFrom": "thread_label_batch_submissions",
+          "tableTo": "historical_thread_label_scans",
+          "columnsFrom": [
+            "historical_scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "thread_label_batch_submissions_scope_check": {
+          "name": "thread_label_batch_submissions_scope_check",
+          "value": "\"thread_label_batch_submissions\".\"historical_scan_id\" is not null or \"thread_label_batch_submissions\".\"status\" in ('complete', 'failed')"
+        },
+        "thread_label_batch_submissions_retry_check": {
+          "name": "thread_label_batch_submissions_retry_check",
+          "value": "\"thread_label_batch_submissions\".\"retry_attempt\" between 0 and 6"
+        },
+        "thread_label_batch_submissions_provider_check": {
+          "name": "thread_label_batch_submissions_provider_check",
+          "value": "\"thread_label_batch_submissions\".\"provider\" = 'openai'"
+        },
+        "thread_label_batch_submissions_status_check": {
+          "name": "thread_label_batch_submissions_status_check",
+          "value": "\"thread_label_batch_submissions\".\"status\" in ('preparing', 'submitted', 'complete', 'failed')"
+        },
+        "thread_label_batch_submissions_request_count_check": {
+          "name": "thread_label_batch_submissions_request_count_check",
+          "value": "\"thread_label_batch_submissions\".\"request_count\" between 1 and 2000"
+        },
+        "thread_label_batch_submissions_definition_hash_check": {
+          "name": "thread_label_batch_submissions_definition_hash_check",
+          "value": "\"thread_label_batch_submissions\".\"definition_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.threads": {
+      "name": "threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "participants": {
+          "name": "participants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "latest_message_at": {
+          "name": "latest_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "content_version": {
+          "name": "content_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "label_analysis_state": {
+          "name": "label_analysis_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_requested'"
+        },
+        "label_analysis_version": {
+          "name": "label_analysis_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "label_analysis_definition_hash": {
+          "name": "label_analysis_definition_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_analysis_after": {
+          "name": "label_analysis_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_analysis_error": {
+          "name": "label_analysis_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label_analyzed_at": {
+          "name": "label_analyzed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "threads_account_provider_thread_idx": {
+          "name": "threads_account_provider_thread_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "threads_user_latest_idx": {
+          "name": "threads_user_latest_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "latest_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "threads_account_label_analysis_idx": {
+          "name": "threads_account_label_analysis_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "label_analysis_state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "latest_message_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "threads_user_id_profiles_id_fk": {
+          "name": "threads_user_id_profiles_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_account_id_connected_accounts_id_fk": {
+          "name": "threads_account_id_connected_accounts_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "threads_message_count_check": {
+          "name": "threads_message_count_check",
+          "value": "\"threads\".\"message_count\" >= 0"
+        },
+        "threads_content_version_check": {
+          "name": "threads_content_version_check",
+          "value": "\"threads\".\"content_version\" > 0"
+        },
+        "threads_label_analysis_state_check": {
+          "name": "threads_label_analysis_state_check",
+          "value": "\"threads\".\"label_analysis_state\" in ('not_requested', 'pending', 'running', 'complete', 'failed')"
+        },
+        "threads_label_analysis_version_check": {
+          "name": "threads_label_analysis_version_check",
+          "value": "\"threads\".\"label_analysis_version\" > 0"
+        },
+        "threads_label_analysis_definition_hash_check": {
+          "name": "threads_label_analysis_definition_hash_check",
+          "value": "\"threads\".\"label_analysis_definition_hash\" is null or \"threads\".\"label_analysis_definition_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workflow_steps": {
+      "name": "workflow_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workflow_steps_idempotency_key_idx": {
+          "name": "workflow_steps_idempotency_key_idx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_steps_run_created_idx": {
+          "name": "workflow_steps_run_created_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_steps_account_type_created_idx": {
+          "name": "workflow_steps_account_type_created_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_steps_user_status_idx": {
+          "name": "workflow_steps_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_steps_run_id_mail_sync_runs_id_fk": {
+          "name": "workflow_steps_run_id_mail_sync_runs_id_fk",
+          "tableFrom": "workflow_steps",
+          "tableTo": "mail_sync_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_steps_user_id_profiles_id_fk": {
+          "name": "workflow_steps_user_id_profiles_id_fk",
+          "tableFrom": "workflow_steps",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflow_steps_account_id_connected_accounts_id_fk": {
+          "name": "workflow_steps_account_id_connected_accounts_id_fk",
+          "tableFrom": "workflow_steps",
+          "tableTo": "connected_accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workflow_steps_status_check": {
+          "name": "workflow_steps_status_check",
+          "value": "\"workflow_steps\".\"status\" in ('queued', 'running', 'complete', 'failed')"
+        },
+        "workflow_steps_attempts_check": {
+          "name": "workflow_steps_attempts_check",
+          "value": "\"workflow_steps\".\"attempts\" >= 0"
+        },
+        "workflow_steps_max_attempts_check": {
+          "name": "workflow_steps_max_attempts_check",
+          "value": "\"workflow_steps\".\"max_attempts\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/drizzle/meta/_journal.json
+++ b/packages/database/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1788176451399,
       "tag": "0037_historical_batch_continuations",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1788186419653,
+      "tag": "0038_shared_gmail_connections",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/gmail-identity.ts
+++ b/packages/database/src/gmail-identity.ts
@@ -1,0 +1,69 @@
+import { and, eq, ne, sql } from "drizzle-orm";
+
+import {
+  getDatabase,
+  type DatabaseExecutor,
+  type DatabaseTransaction,
+} from "./client";
+import { connectedAccounts } from "./schema";
+
+// Every lifecycle operation takes this lock before account/replica row locks.
+// Use the supplied transaction for all database work: waiters must never hold
+// the query pool while the lock holder needs another query connection.
+export async function withGmailIdentityLock<T>(
+  providerAccountId: string,
+  operation: (transaction: DatabaseTransaction) => Promise<T>,
+  database: DatabaseExecutor = getDatabase(),
+): Promise<T> {
+  return database.transaction(async (transaction) => {
+    await transaction.execute(sql`select pg_advisory_xact_lock(
+      hashtextextended(${`invook:gmail-identity:${providerAccountId}`}, 0)
+    )`);
+    return operation(transaction);
+  });
+}
+
+export class GmailConnectionDeletingError extends Error {
+  constructor() {
+    super("The Gmail connection is still disconnecting.");
+    this.name = "GmailConnectionDeletingError";
+  }
+}
+
+export async function getGmailIdentityConnection(
+  accountId: string,
+  database: DatabaseExecutor = getDatabase(),
+): Promise<typeof connectedAccounts.$inferSelect | null> {
+  const [account] = await database
+    .select()
+    .from(connectedAccounts)
+    .where(
+      and(
+        eq(connectedAccounts.id, accountId),
+        eq(connectedAccounts.provider, "gmail"),
+      ),
+    )
+    .limit(1);
+  return account ?? null;
+}
+
+// reconnect_required connections still own a replica and need notifications
+// once authorization is restored. Never stop their mailbox watch either.
+export async function hasOtherGmailConnections(
+  input: { accountId: string; providerAccountId: string },
+  database: DatabaseExecutor = getDatabase(),
+): Promise<boolean> {
+  const [account] = await database
+    .select({ id: connectedAccounts.id })
+    .from(connectedAccounts)
+    .where(
+      and(
+        eq(connectedAccounts.provider, "gmail"),
+        eq(connectedAccounts.providerAccountId, input.providerAccountId),
+        ne(connectedAccounts.id, input.accountId),
+        ne(connectedAccounts.status, "disconnected"),
+      ),
+    )
+    .limit(1);
+  return Boolean(account);
+}

--- a/packages/database/src/gmail-push-notifications.test.ts
+++ b/packages/database/src/gmail-push-notifications.test.ts
@@ -49,7 +49,7 @@ test(
         database,
       );
 
-      assert.deepEqual(result, { status: "ignored", accountId: null });
+      assert.deepEqual(result, { status: "accepted", connections: [] });
     } finally {
       await client.end();
     }
@@ -120,7 +120,7 @@ test(
           ]);
           assert.deepEqual(
             results,
-            Array.from({ length: 12 }, () => ({ status: "retry" })),
+            Array.from({ length: 12 }, () => ({ status: "retry", connections: [{ status: "retry" }] })),
           );
           assert.equal(readableReplica[0]?.pendingHistoryCursor, null);
           const admittedSteps = await database.select().from(workflowSteps)
@@ -133,12 +133,14 @@ test(
         { emailAddress, notificationHistoryId: "150" },
         database,
       );
-      assert.equal(redelivered.status, "queued");
+      assert.equal(redelivered.status, "accepted");
+      assert.equal(redelivered.connections[0]?.status, "queued");
       const duplicate = await recordGmailPushNotification(
         { emailAddress, notificationHistoryId: "150" },
         database,
       );
-      assert.equal(duplicate.status, "coalesced");
+      assert.equal(duplicate.status, "accepted");
+      assert.equal(duplicate.connections[0]?.status, "coalesced");
       const [replica] = await database.select().from(gmailReplicaStates)
         .where(eq(gmailReplicaStates.accountId, accountId));
       assert.equal(replica?.pendingHistoryCursor, "150");
@@ -223,8 +225,8 @@ test(
         { emailAddress, notificationHistoryId: "140" },
         database,
       );
-      assert.equal(first.status, "queued");
-      assert.equal(reordered.status, "coalesced");
+      assert.equal(first.connections[0]?.status, "queued");
+      assert.equal(reordered.connections[0]?.status, "coalesced");
 
       assert.equal(
         await markGmailReplicaReady(

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -6,6 +6,7 @@ export {
   listenForMailboxChangeNotifications,
   withGmailAccountControlLock,
   type Database,
+  type DatabaseExecutor,
 } from "./client";
 export {
   decryptGoogleCredential,
@@ -22,6 +23,7 @@ export * from "./mailbox-change-events";
 export * from "./mailbox-resources";
 export * from "./mailbox-query";
 export * from "./gmail-watch";
+export * from "./gmail-identity";
 export * from "./repositories";
 export * from "./replica";
 export * from "./schema";

--- a/packages/database/src/mailbox-visibility.ts
+++ b/packages/database/src/mailbox-visibility.ts
@@ -58,8 +58,7 @@ export function mailboxViewCondition(view: MailboxView) {
     const labelId = view.slice(6);
     // One Invook label exists per connected account, so the view matches every
     // account label the signed-in user owns under the selected label's name.
-    return sql<boolean>`
-      (${inboxThreadCondition()}) and exists (
+    return sql<boolean>`exists (
         select 1 from ${threadLabelAssignments} assignment
         inner join ${labels} assignment_label
           on assignment_label.id = assignment.label_id
@@ -74,15 +73,13 @@ export function mailboxViewCondition(view: MailboxView) {
               and selected_label.user_id = ${outerThreadUserId}
               and selected_label.kind = 'invook'
           )
-      )
-    `;
+      )`;
   }
   switch (view) {
     case "all":
-      return inboxThreadCondition();
+      return visibleThreadCondition();
     case "important":
-      return sql<boolean>`
-        (${inboxThreadCondition()}) and exists (
+      return sql<boolean>`exists (
           select 1 from ${threadLabelAssignments} important_assignment
           inner join ${labels} important_label
             on important_label.id = important_assignment.label_id
@@ -91,8 +88,7 @@ export function mailboxViewCondition(view: MailboxView) {
             and important_label.account_id = ${outerThreadAccountId}
             and important_label.kind = 'invook'
             and important_label.system_key = 'important'
-        )
-      `;
+        )`;
     case "starred":
     case "drafts":
     case "sent":

--- a/packages/database/src/partial-replica.integration.test.ts
+++ b/packages/database/src/partial-replica.integration.test.ts
@@ -391,6 +391,80 @@ test(
 );
 
 test(
+  "All and Invook label views count every stored thread in the selected account",
+  { skip: !testDatabaseUrl },
+  async () => {
+    await withPartialReplicaFixture(async (fixture) => {
+      const { database, userId, accountId, threadId, invookLabelId } = fixture;
+      const archivedThreadId = uuidv4();
+      const archivedMessageId = uuidv4();
+      const sentAt = new Date("2026-08-14T08:00:00.000Z");
+
+      await database.insert(threads).values({
+        id: archivedThreadId,
+        userId,
+        accountId,
+        providerThreadId: `provider-thread-${archivedThreadId}`,
+        subject: "Stored outside Gmail Inbox",
+        snippet: "This thread remains available in the Invook replica.",
+        participants: ["Archived Sender <archived@example.com>"],
+        latestMessageAt: sentAt,
+        messageCount: 1,
+      });
+      await database.insert(messages).values({
+        id: archivedMessageId,
+        userId,
+        accountId,
+        threadId: archivedThreadId,
+        providerMessageId: `provider-message-${archivedMessageId}`,
+        direction: "incoming",
+        sender: {
+          raw: "Archived Sender <archived@example.com>",
+          email: "archived@example.com",
+        },
+        recipients: ["owner@example.com"],
+        providerHistoryId: "104",
+        internalDate: sentAt,
+        headerLines: [],
+        subject: "Stored outside Gmail Inbox",
+        snippet: "This thread remains available in the Invook replica.",
+        bodyText: "Stored locally without a Gmail Inbox membership.",
+        sentAt,
+      });
+      await database.insert(threadLabelAssignments).values({
+        userId,
+        accountId,
+        threadId: archivedThreadId,
+        labelId: invookLabelId,
+        source: "user",
+        definitionVersion: 1,
+      });
+
+      const [allThreads, labelThreads, sidebarCounts] = await Promise.all([
+        listMailboxThreads(userId, { accountId, view: "all" }, database),
+        listMailboxThreads(
+          userId,
+          { accountId, view: `label:${invookLabelId}` },
+          database,
+        ),
+        getMailboxSidebarCounts(userId, database),
+      ]);
+
+      assert.deepEqual(
+        allThreads?.threads.map((thread) => thread.id).sort(),
+        [threadId, archivedThreadId].sort(),
+      );
+      assert.deepEqual(
+        labelThreads?.threads.map((thread) => thread.id).sort(),
+        [threadId, archivedThreadId].sort(),
+      );
+      assert.equal(sidebarCounts?.accounts[accountId]?.views.all, 2);
+      assert.equal(sidebarCounts?.accounts[accountId]?.labels[invookLabelId], 2);
+    });
+  },
+);
+
+test(
   "mailbox account scopes preserve every account and aggregate All",
   { skip: !testDatabaseUrl },
   async () => {

--- a/packages/database/src/replica.ts
+++ b/packages/database/src/replica.ts
@@ -1,10 +1,11 @@
-import { and, desc, DrizzleQueryError, eq, inArray, isNotNull, not } from "drizzle-orm";
+import { and, desc, DrizzleQueryError, eq, inArray, isNotNull, not, sql } from "drizzle-orm";
 import postgres from "postgres";
 import { v4 as uuidv4 } from "uuid";
 
 import type { GmailForwardMessage } from "@invook/contracts/gmail-forward";
 
-import { getDatabase, type Database } from "./client";
+import { getDatabase, type Database, type DatabaseExecutor } from "./client";
+import { withGmailIdentityLock } from "./gmail-identity";
 import { insertMailboxChange } from "./mailbox-change-events";
 import { visibleThreadCondition } from "./mailbox-visibility";
 import { enqueueLiveInboxThreadLabelAnalyses } from "./thread-label-analysis";
@@ -668,7 +669,7 @@ export async function setGmailReplicaState(
 
 export async function saveGmailWatchState(
   input: { accountId: string; watch: GmailWatchInput; renewedAt: Date },
-  database: Database = getDatabase(),
+  database: DatabaseExecutor = getDatabase(),
 ) {
   await database.transaction(async (transaction) => {
     const [account] = await transaction
@@ -703,10 +704,15 @@ export async function saveGmailWatchState(
   });
 }
 
-type GmailPushNotificationResult =
+type GmailConnectionPushResult =
   | { status: "retry" }
   | { status: "ignored"; accountId: null }
   | { status: "coalesced" | "queued"; accountId: string; stepId: string };
+
+type GmailPushNotificationResult = {
+  status: "retry" | "accepted";
+  connections: GmailConnectionPushResult[];
+};
 
 export async function recordGmailPushNotification(
   input: {
@@ -719,14 +725,39 @@ export async function recordGmailPushNotification(
     throw new Error("The Gmail notification history cursor is invalid.");
   }
   const executor = database ?? getDatabase();
-  return executor.transaction<GmailPushNotificationResult>(async (transaction) => {
+  const accounts = await executor.select({ id: connectedAccounts.id })
+    .from(connectedAccounts).where(and(
+      eq(connectedAccounts.provider, "gmail"),
+      sql`lower(${connectedAccounts.email}) = ${input.emailAddress.trim().toLowerCase()}`,
+      eq(connectedAccounts.status, "connected"),
+    ));
+  const connections: GmailConnectionPushResult[] = [];
+  // Independent commits preserve successful admissions when a sibling is busy.
+  // Sequential, non-waiting admission also bounds query-pool use for fan-out.
+  for (const account of accounts) {
+    connections.push(await recordGmailConnectionPush({
+      accountId: account.id,
+      notificationHistoryId: input.notificationHistoryId,
+    }, executor));
+  }
+  return {
+    status: connections.some((connection) => connection.status === "retry") ? "retry" : "accepted",
+    connections,
+  };
+}
+
+async function recordGmailConnectionPush(
+  input: { accountId: string; notificationHistoryId: string },
+  executor: Database,
+): Promise<GmailConnectionPushResult> {
+  return executor.transaction<GmailConnectionPushResult>(async (transaction) => {
     const [account] = await transaction
       .select({ id: connectedAccounts.id, userId: connectedAccounts.userId })
       .from(connectedAccounts)
       .where(
         and(
           eq(connectedAccounts.provider, "gmail"),
-          eq(connectedAccounts.email, input.emailAddress),
+          eq(connectedAccounts.id, input.accountId),
           eq(connectedAccounts.status, "connected"),
         ),
       )
@@ -758,7 +789,7 @@ export async function recordGmailPushNotification(
         .where(eq(gmailReplicaStates.accountId, account.id));
     }
 
-    const stepId = await enqueueWorkflowStep(
+    const stepId = await enqueueWorkflowStepWithExecutor(
       {
         userId: account.userId,
         accountId: account.id,
@@ -766,14 +797,14 @@ export async function recordGmailPushNotification(
         payload: { reason: "notification" },
         idempotencyKey: `gmail-history-notification:${account.id}:${nextPending}`,
       },
-      transaction as unknown as Database,
+      transaction,
     );
     return {
       status: isAdvanced ? "queued" : "coalesced",
       accountId: account.id,
       stepId,
     };
-  }).catch((error: unknown): GmailPushNotificationResult => {
+  }).catch((error: unknown): GmailConnectionPushResult => {
     const cause = error instanceof DrizzleQueryError ? error.cause : error;
     if (cause instanceof postgres.PostgresError && cause.code === "55P03") {
       // The transaction has rolled back. Never acknowledge an unstored cursor.
@@ -1121,7 +1152,7 @@ export async function getMailboxChangeEvent(
 
 export async function listGmailObjectKeysForAccount(
   accountId: string,
-  database: Database = getDatabase(),
+  database: DatabaseExecutor = getDatabase(),
 ) {
   const attachmentObjects = await database
     .select({ key: messageAttachments.objectKey })
@@ -1143,9 +1174,15 @@ export async function listGmailObjectKeysForAccount(
 
 export async function markGmailReplicaDeleting(
   input: { userId: string; accountId: string },
-  database: Database = getDatabase(),
+  database: DatabaseExecutor = getDatabase(),
 ) {
-  return database.transaction(async (transaction) => {
+  const [identity] = await database.select({ providerAccountId: connectedAccounts.providerAccountId })
+    .from(connectedAccounts).where(and(
+      eq(connectedAccounts.id, input.accountId),
+      eq(connectedAccounts.userId, input.userId),
+    )).limit(1);
+  if (!identity) return null;
+  return withGmailIdentityLock(identity.providerAccountId, async (transaction) => {
     const [account] = await transaction
       .select({ id: connectedAccounts.id })
       .from(connectedAccounts)
@@ -1199,7 +1236,7 @@ export async function markGmailReplicaDeleting(
       transaction as unknown as Database,
     );
     return cleanup.id;
-  });
+  }, database);
 }
 
 export async function markGmailReplicaDeletingForUser(
@@ -1230,7 +1267,7 @@ export async function markGmailReplicaDeletingForUser(
 
 export async function markGmailAccountCleanupRunning(
   cleanupId: string,
-  database: Database = getDatabase(),
+  database: DatabaseExecutor = getDatabase(),
 ) {
   await database
     .update(gmailAccountCleanups)

--- a/packages/database/src/repositories.ts
+++ b/packages/database/src/repositories.ts
@@ -42,6 +42,7 @@ import {
 } from "./thread-label-analysis";
 import { createHistoricalThreadLabelScan } from "./historical-thread-label-batches";
 import { enqueueDailyGmailWatchRenewal } from "./gmail-watch";
+import { GmailConnectionDeletingError, withGmailIdentityLock } from "./gmail-identity";
 import { deriveMailSyncProgress } from "./mail-sync-progress";
 import {
   inboxThreadCondition,
@@ -147,8 +148,8 @@ export async function checkDatabaseConnection(
 }
 
 export async function getGmailConnectionForOAuth(
-  providerAccountId: string,
-  database: Database = getDatabase(),
+  input: { userId: string; providerAccountId: string },
+  database: DatabaseExecutor = getDatabase(),
 ) {
   const [connection] = await database
     .select({
@@ -161,7 +162,8 @@ export async function getGmailConnectionForOAuth(
     .where(
       and(
         eq(connectedAccounts.provider, "gmail"),
-        eq(connectedAccounts.providerAccountId, providerAccountId),
+        eq(connectedAccounts.providerAccountId, input.providerAccountId),
+        eq(connectedAccounts.userId, input.userId),
       ),
     )
     .limit(1);
@@ -171,7 +173,7 @@ export async function getGmailConnectionForOAuth(
 
 export async function getGmailConnectionForUser(
   input: { userId: string; accountId: string },
-  database: Database = getDatabase(),
+  database: DatabaseExecutor = getDatabase(),
 ) {
   const [connection] = await database
     .select({
@@ -299,18 +301,9 @@ export function getReturningGmailAuthenticationAction(input: {
   return "none";
 }
 
-async function lockGmailAuthentication(
-  transaction: DatabaseTransaction,
-  providerAccountId: string,
-) {
-  await transaction.execute(
-    sql`select pg_advisory_xact_lock(hashtextextended(${`invook:gmail-auth:${providerAccountId}`}, 0))`,
-  );
-}
-
 async function findGmailAuthenticationAccount(
   transaction: DatabaseTransaction,
-  providerAccountId: string,
+  input: { userId: string; providerAccountId: string },
 ): Promise<GmailAuthenticationAccount | null> {
   const [account] = await transaction
     .select({
@@ -328,7 +321,8 @@ async function findGmailAuthenticationAccount(
     .where(
       and(
         eq(connectedAccounts.provider, "gmail"),
-        eq(connectedAccounts.providerAccountId, providerAccountId),
+        eq(connectedAccounts.providerAccountId, input.providerAccountId),
+        eq(connectedAccounts.userId, input.userId),
       ),
     )
     .limit(1);
@@ -432,9 +426,7 @@ async function saveReturningGmailAuthentication(
   input: GmailAuthenticationInput,
   account: GmailAuthenticationAccount,
 ) {
-  if (account.userId !== input.userId) {
-    throw new Error("This Gmail account is already linked to another Invook user.");
-  }
+  if (account.status === "disconnected") throw new GmailConnectionDeletingError();
   await saveGmailAccountAndCredential(transaction, input, account.id);
   const authenticationAction = getReturningGmailAuthenticationAction({
     status: account.status,
@@ -486,28 +478,26 @@ async function saveReturningGmailAuthentication(
 
 export async function refreshGmailAuthentication(
   input: GmailAuthenticationInput,
-  database: Database = getDatabase(),
+  database: DatabaseExecutor = getDatabase(),
 ): Promise<{ id: string } | null> {
-  return database.transaction(async (transaction) => {
-    await lockGmailAuthentication(transaction, input.providerAccountId);
+  return withGmailIdentityLock(input.providerAccountId, async (transaction) => {
     const account = await findGmailAuthenticationAccount(
       transaction,
-      input.providerAccountId,
+      input,
     );
     if (!account) return null;
     return saveReturningGmailAuthentication(transaction, input, account);
-  });
+  }, database);
 }
 
 export async function saveNewGmailConnection(
   input: NewGmailConnectionInput,
-  database: Database = getDatabase(),
+  database: DatabaseExecutor = getDatabase(),
 ): Promise<{ id: string; created: boolean }> {
-  return database.transaction(async (transaction) => {
-    await lockGmailAuthentication(transaction, input.providerAccountId);
+  return withGmailIdentityLock(input.providerAccountId, async (transaction) => {
     const existingAccount = await findGmailAuthenticationAccount(
       transaction,
-      input.providerAccountId,
+      input,
     );
     if (existingAccount) {
       const account = await saveReturningGmailAuthentication(
@@ -570,7 +560,7 @@ export async function saveNewGmailConnection(
     });
 
     return { ...account, created: true };
-  });
+  }, database);
 }
 
 export async function hasConnectedGmailAccount(
@@ -1049,7 +1039,7 @@ export async function getAccountSyncStateForUser(
 
 export async function getWorkerAccount(
   accountId: string,
-  database: Database = getDatabase(),
+  database: DatabaseExecutor = getDatabase(),
 ) {
   const [account] = await database
     .select({
@@ -1078,7 +1068,7 @@ export async function getWorkerAccount(
 export async function updateStoredCredential(
   accountId: string,
   tokenCiphertext: string,
-  database: Database = getDatabase(),
+  database: DatabaseExecutor = getDatabase(),
 ) {
   await database
     .update(accountSecrets)

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -160,10 +160,15 @@ export const connectedAccounts = pgTable(
       .$onUpdate(() => new Date()),
   },
   (table) => [
-    uniqueIndex("connected_accounts_provider_identity_idx").on(
+    uniqueIndex("connected_accounts_user_provider_identity_idx").on(
+      table.userId,
       table.provider,
       table.providerAccountId,
     ),
+    index("connected_accounts_provider_identity_idx").on(table.provider, table.providerAccountId),
+    index("connected_accounts_active_email_idx")
+      .on(sql`lower(${table.email})`)
+      .where(sql`${table.status} = 'connected'`),
     index("connected_accounts_user_created_idx").on(table.userId, table.createdAt),
     index("connected_accounts_active_user_idx")
       .on(table.userId)

--- a/packages/database/src/shared-gmail-connections.integration.test.ts
+++ b/packages/database/src/shared-gmail-connections.integration.test.ts
@@ -1,0 +1,577 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { and, eq, inArray } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { v4 as uuidv4 } from "uuid";
+
+import { encryptGoogleCredential } from "./credentials";
+import { GmailConnectionDeletingError } from "./gmail-identity";
+import {
+  getMailboxSettings,
+  getMailboxThreadDetail,
+  getMailboxEventRecoveryContextForUser,
+} from "./mailbox-resources";
+import {
+  createGmailConnectionRequest,
+  consumeGmailConnectionRequest,
+  createInvookLabel,
+  getGmailConnectionForOAuth,
+  getGmailConnectionForUser,
+  getMailboxAttachmentDownloadForUser,
+  refreshGmailAuthentication,
+  saveNewGmailConnection,
+} from "./repositories";
+import {
+  applyGmailHistoryBatch,
+  getGmailProviderWriteContextForAccount,
+  listGmailObjectKeysForAccount,
+  markGmailReplicaDeleting,
+  recordGmailPushNotification,
+} from "./replica";
+import * as schema from "./schema";
+import {
+  accountSecrets,
+  connectedAccounts,
+  gmailReplicaStates,
+  labels,
+  mailboxChangeEvents,
+  memoryEntries,
+  messageAttachments,
+  messages,
+  profiles,
+  temporalCommands,
+  threads,
+  workflowSteps,
+} from "./schema";
+
+const testDatabaseUrl = process.env.TEST_DATABASE_URL;
+
+test(
+  "A connects Gmail A/B and B independently connects Gmail A/C",
+  { skip: !testDatabaseUrl },
+  async (t) => {
+    assert.ok(testDatabaseUrl);
+    const testSchema = `shared_connections_${uuidv4().replaceAll("-", "")}`;
+    const client = postgres(testDatabaseUrl, {
+      max: 4,
+      prepare: false,
+      onnotice: () => {},
+      connection: { search_path: `${testSchema},public` },
+    });
+    const database = drizzle(client, { schema });
+    const userA = uuidv4();
+    const userB = uuidv4();
+    const gmailA = uuidv4();
+    const gmailB = uuidv4();
+    const gmailC = uuidv4();
+    const encryptionKey = Buffer.alloc(32, 4).toString("base64");
+    const authentication = (userId: string, providerAccountId: string) => ({
+      userId,
+      providerAccountId,
+      email: `${providerAccountId}@example.test`,
+      image: null,
+      scopes: ["https://www.googleapis.com/auth/gmail.modify"],
+      currentHistoryId: "100",
+      initialHistoryId: "100",
+      authenticatedAt: new Date(),
+      tokenCiphertext: encryptGoogleCredential(
+        {
+          accessToken: `access-${userId}`,
+          refreshToken: `refresh-${userId}`,
+          expiresAt: "2030-01-01T00:00:00Z",
+          scopes: [],
+        },
+        encryptionKey,
+      ),
+      watch: {
+        topicName: "projects/test/topics/gmail",
+        historyId: "100",
+        expirationAt: new Date("2030-01-08T00:00:00Z"),
+        renewedAt: new Date("2030-01-01T00:00:00Z"),
+      },
+    });
+    try {
+      await client.unsafe(`CREATE SCHEMA "${testSchema}"`);
+      await client.unsafe(
+        "CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public",
+      );
+      const migrationsUrl = new URL("../drizzle/", import.meta.url);
+      for (const filename of (await readdir(migrationsUrl))
+        .filter((name) => /^\d{4}_.+\.sql$/.test(name))
+        .sort()) {
+        const migration = await readFile(
+          new URL(filename, migrationsUrl),
+          "utf8",
+        );
+        for (const statement of migration
+          .replaceAll('"public".', `"${testSchema}".`)
+          .split("--> statement-breakpoint")) {
+          if (statement.trim()) await client.unsafe(statement);
+        }
+      }
+      await database.insert(profiles).values(
+        [userA, userB].map((userId) => ({
+          id: userId,
+          email: `${userId}@example.test`,
+          displayName: "Shared mailbox test",
+        })),
+      );
+      const aaInput = authentication(userA, gmailA);
+      const baInput = authentication(userB, gmailA);
+      const aa = await saveNewGmailConnection(aaInput, database);
+      // No credentials are available to B before B independently authorizes A.
+      assert.equal(
+        await getGmailConnectionForOAuth(
+          { userId: userB, providerAccountId: gmailA },
+          database,
+        ),
+        null,
+      );
+      const [ab, ba, bc] = await Promise.all([
+        saveNewGmailConnection(authentication(userA, gmailB), database),
+        saveNewGmailConnection(baInput, database),
+        saveNewGmailConnection(authentication(userB, gmailC), database),
+      ]);
+      const accountIds = [aa.id, ab.id, ba.id, bc.id];
+      assert.equal(new Set(accountIds).size, 4);
+
+      await t.test(
+        "OAuth requests are independent, single-use, and credentials are user scoped",
+        async () => {
+          for (const userId of [userA, userB]) {
+            const state = uuidv4();
+            await createGmailConnectionRequest(
+              {
+                state,
+                codeVerifier: userId,
+                userId,
+                accountId: null,
+                expiresAt: new Date(Date.now() + 60_000),
+              },
+              database,
+            );
+            assert.equal(
+              (
+                await consumeGmailConnectionRequest(
+                  { state, consumedAt: new Date() },
+                  database,
+                )
+              )?.userId,
+              userId,
+            );
+            assert.equal(
+              await consumeGmailConnectionRequest(
+                { state, consumedAt: new Date() },
+                database,
+              ),
+              null,
+            );
+          }
+          assert.equal(
+            (
+              await getGmailConnectionForOAuth(
+                { userId: userA, providerAccountId: gmailA },
+                database,
+              )
+            )?.id,
+            aa.id,
+          );
+          assert.equal(
+            (
+              await getGmailConnectionForOAuth(
+                { userId: userB, providerAccountId: gmailA },
+                database,
+              )
+            )?.id,
+            ba.id,
+          );
+          assert.equal(
+            await getGmailConnectionForUser(
+              { userId: userA, accountId: ba.id },
+              database,
+            ),
+            null,
+          );
+          assert.equal(
+            await getGmailProviderWriteContextForAccount(
+              { userId: userA, accountId: ba.id },
+              database,
+            ),
+            null,
+          );
+          assert.equal(
+            (
+              await getGmailProviderWriteContextForAccount(
+                { userId: userB, accountId: ba.id },
+                database,
+              )
+            )?.tokenCiphertext,
+            baInput.tokenCiphertext,
+          );
+          const updated = {
+            ...aaInput,
+            tokenCiphertext: "new-user-a-ciphertext",
+          };
+          await refreshGmailAuthentication(updated, database);
+          const [bSecret] = await database
+            .select()
+            .from(accountSecrets)
+            .where(eq(accountSecrets.accountId, ba.id));
+          assert.equal(bSecret?.tokenCiphertext, baInput.tokenCiphertext);
+        },
+      );
+
+      await t.test(
+        "concurrent duplicate connects retain one connection per user and identity",
+        async () => {
+          const duplicates = await Promise.all(
+            Array.from({ length: 8 }, () =>
+              saveNewGmailConnection(aaInput, database),
+            ),
+          );
+          assert.ok(
+            duplicates.every(
+              (result) => result.id === aa.id && !result.created,
+            ),
+          );
+          const accounts = await database
+            .select()
+            .from(connectedAccounts)
+            .where(inArray(connectedAccounts.userId, [userA, userB]));
+          assert.equal(accounts.length, 4);
+          await assert.rejects(
+            database.insert(connectedAccounts).values({
+              userId: userA,
+              providerAccountId: gmailA,
+              email: aaInput.email,
+              memoryAcknowledgedAt: new Date(),
+            }),
+            (error: unknown) =>
+              error instanceof Error &&
+              error.cause instanceof postgres.PostgresError &&
+              error.cause.code === "23505",
+          );
+        },
+      );
+
+      await t.test(
+        "labels, preferences, Memory, replicas, attachment keys and event audiences stay isolated",
+        async () => {
+          for (const [userId, accountId] of [
+            [userA, aa.id],
+            [userB, ba.id],
+          ]) {
+            assert.ok(userId && accountId);
+            await createInvookLabel(
+              {
+                userId,
+                accountId,
+                name: "Private",
+                description: `Only ${userId}`,
+              },
+              database,
+            );
+            await database.insert(memoryEntries).values({
+              userId,
+              accountId,
+              memoryType: "preference",
+              statement: `Preference ${userId}`,
+              source: "user",
+              fingerprint: "same-fingerprint",
+            });
+            const threadId = uuidv4();
+            const messageId = uuidv4();
+            const attachmentId = uuidv4();
+            const objectKey = `${accountId}/messages/shared-message/attachments/0-checksum`;
+            await database.insert(threads).values({
+              id: threadId,
+              userId,
+              accountId,
+              providerThreadId: "shared-thread",
+              messageCount: 1,
+            });
+            await database.insert(messages).values({
+              id: messageId,
+              userId,
+              accountId,
+              threadId,
+              providerMessageId: "shared-message",
+              direction: "incoming",
+              sender: {
+                raw: "sender@example.test",
+                email: "sender@example.test",
+              },
+              internalDate: new Date(),
+              sentAt: new Date(),
+            });
+            await database.insert(messageAttachments).values({
+              id: attachmentId,
+              userId,
+              accountId,
+              messageId,
+              objectKey,
+              filename: "test.txt",
+            });
+            const otherUserId = userId === userA ? userB : userA;
+            assert.equal(
+              await getMailboxSettings(otherUserId, accountId, database),
+              null,
+            );
+            assert.equal(
+              await getMailboxThreadDetail(
+                otherUserId,
+                threadId,
+                null,
+                database,
+              ),
+              null,
+            );
+            assert.equal(
+              await getMailboxAttachmentDownloadForUser(
+                { userId: otherUserId, attachmentId },
+                database,
+              ),
+              null,
+            );
+            assert.deepEqual(
+              await listGmailObjectKeysForAccount(accountId, database),
+              [objectKey],
+            );
+            const settings = await getMailboxSettings(
+              userId,
+              accountId,
+              database,
+            );
+            assert.equal(
+              settings?.memories[0]?.statement,
+              `Preference ${userId}`,
+            );
+            assert.equal(
+              settings?.invookLabels.find((label) => label.name === "Private")
+                ?.description,
+              `Only ${userId}`,
+            );
+            await applyGmailHistoryBatch(
+              {
+                userId,
+                accountId,
+                expectedCursor: "100",
+                nextCursor: "200",
+                messages: [],
+                labelChanges: [
+                  {
+                    providerMessageId: "shared-message",
+                    providerHistoryId: "200",
+                    gmailLabels: [
+                      { providerLabelId: "STARRED", name: "Starred" },
+                    ],
+                  },
+                ],
+                deletedMessageIds: [],
+              },
+              database,
+            );
+          }
+          assert.deepEqual(
+            new Set(
+              (
+                await getMailboxEventRecoveryContextForUser(userA, database)
+              )?.accountIds,
+            ),
+            new Set([aa.id, ab.id]),
+          );
+          assert.deepEqual(
+            new Set(
+              (
+                await getMailboxEventRecoveryContextForUser(userB, database)
+              )?.accountIds,
+            ),
+            new Set([ba.id, bc.id]),
+          );
+          const events = await database
+            .select()
+            .from(mailboxChangeEvents)
+            .where(inArray(mailboxChangeEvents.accountId, accountIds));
+          assert.ok(
+            events.some(
+              (event) => event.accountId === aa.id && event.userId === userA,
+            ),
+          );
+          assert.ok(
+            events.some(
+              (event) => event.accountId === ba.id && event.userId === userB,
+            ),
+          );
+          const privateLabels = await database
+            .select()
+            .from(labels)
+            .where(
+              and(
+                inArray(labels.accountId, [aa.id, ba.id]),
+                eq(labels.name, "Private"),
+              ),
+            );
+          assert.equal(new Set(privateLabels.map((label) => label.id)).size, 2);
+        },
+      );
+
+      await t.test(
+        "fan-out commits idle connections despite busy siblings and redelivery is idempotent",
+        async () => {
+          await database
+            .update(gmailReplicaStates)
+            .set({
+              historyCursor: "100",
+              pendingHistoryCursor: null,
+              state: "ready",
+            })
+            .where(eq(gmailReplicaStates.accountId, aa.id));
+          await database
+            .update(gmailReplicaStates)
+            .set({
+              historyCursor: "200",
+              pendingHistoryCursor: null,
+              state: "ready",
+            })
+            .where(eq(gmailReplicaStates.accountId, ba.id));
+          for (const lockTarget of ["account", "replica"] as const) {
+            await database.transaction(async (busy) => {
+              if (lockTarget === "account") {
+                await busy
+                  .select()
+                  .from(connectedAccounts)
+                  .where(eq(connectedAccounts.id, ba.id))
+                  .for("update");
+              } else {
+                await busy
+                  .select()
+                  .from(gmailReplicaStates)
+                  .where(eq(gmailReplicaStates.accountId, ba.id))
+                  .for("update");
+              }
+              const results = await Promise.all(
+                Array.from({ length: 12 }, () =>
+                  recordGmailPushNotification(
+                    {
+                      emailAddress: aaInput.email.toUpperCase(),
+                      notificationHistoryId: "300",
+                    },
+                    database,
+                  ),
+                ),
+              );
+              assert.ok(results.every((result) => result.status === "retry"));
+              const [idle] = await database
+                .select()
+                .from(gmailReplicaStates)
+                .where(eq(gmailReplicaStates.accountId, aa.id));
+              assert.equal(idle?.pendingHistoryCursor, "300");
+              assert.equal(idle?.historyCursor, "100");
+            });
+          }
+          const delivery = {
+            emailAddress: aaInput.email,
+            notificationHistoryId: "300",
+          };
+          assert.equal(
+            (await recordGmailPushNotification(delivery, database)).status,
+            "accepted",
+          );
+          assert.equal(
+            (await recordGmailPushNotification(delivery, database)).status,
+            "accepted",
+          );
+          await recordGmailPushNotification(
+            { ...delivery, notificationHistoryId: "250" },
+            database,
+          );
+          const catchups = await database
+            .select()
+            .from(workflowSteps)
+            .where(
+              and(
+                inArray(workflowSteps.accountId, accountIds),
+                eq(workflowSteps.stepType, "gmail.history.catchup"),
+              ),
+            );
+          assert.deepEqual(
+            new Set(catchups.map((step) => step.idempotencyKey)),
+            new Set(
+              [aa.id, ba.id].map(
+                (id) => `gmail-history-notification:${id}:300`,
+              ),
+            ),
+          );
+          const commands = await database
+            .select()
+            .from(temporalCommands)
+            .where(
+              inArray(
+                temporalCommands.workflowStepId,
+                catchups.map((step) => step.id),
+              ),
+            );
+          assert.equal(commands.length, 2);
+          const replicas = await database
+            .select()
+            .from(gmailReplicaStates)
+            .where(inArray(gmailReplicaStates.accountId, accountIds));
+          assert.equal(
+            replicas.find((replica) => replica.accountId === ba.id)
+              ?.historyCursor,
+            "200",
+          );
+          assert.ok(
+            replicas
+              .filter((replica) => [ab.id, bc.id].includes(replica.accountId))
+              .every((replica) => replica.pendingHistoryCursor === null),
+          );
+        },
+      );
+
+      await t.test(
+        "disconnect cannot cross ownership or resurrect an account awaiting cleanup",
+        async () => {
+          assert.equal(
+            await markGmailReplicaDeleting(
+              { userId: userB, accountId: aa.id },
+              database,
+            ),
+            null,
+          );
+          assert.ok(
+            await markGmailReplicaDeleting(
+              { userId: userA, accountId: aa.id },
+              database,
+            ),
+          );
+          await assert.rejects(
+            refreshGmailAuthentication(aaInput, database),
+            GmailConnectionDeletingError,
+          );
+          await assert.rejects(
+            saveNewGmailConnection(aaInput, database),
+            GmailConnectionDeletingError,
+          );
+          const notification = await recordGmailPushNotification(
+            { emailAddress: aaInput.email, notificationHistoryId: "400" },
+            database,
+          );
+          assert.equal(notification.status, "accepted");
+          assert.equal(notification.connections.length, 1);
+          const [stillConnected] = await database
+            .select()
+            .from(connectedAccounts)
+            .where(eq(connectedAccounts.id, ba.id));
+          assert.equal(stillConnected?.status, "connected");
+        },
+      );
+    } finally {
+      await client.unsafe(`DROP SCHEMA IF EXISTS "${testSchema}" CASCADE`);
+      await client.end();
+    }
+  },
+);

--- a/packages/database/src/shared-gmail-migration.integration.test.ts
+++ b/packages/database/src/shared-gmail-migration.integration.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import test from "node:test";
+
+import postgres from "postgres";
+import { v4 as uuidv4 } from "uuid";
+
+const testDatabaseUrl = process.env.TEST_DATABASE_URL;
+const migrationsUrl = new URL("../drizzle/", import.meta.url);
+
+test(
+  "0038 upgrades PR #45 without changing connection IDs, credentials, cursors, or label policy",
+  { skip: !testDatabaseUrl },
+  async () => {
+    assert.ok(testDatabaseUrl);
+    const client = postgres(testDatabaseUrl, {
+      max: 1,
+      prepare: false,
+      onnotice: () => {},
+    });
+    const testSchema = `shared_gmail_${uuidv4().replaceAll("-", "")}`;
+    const userA = uuidv4();
+    const userB = uuidv4();
+    const accountId = uuidv4();
+    const providerAccountId = uuidv4();
+    const labelId = uuidv4();
+    async function apply(filename: string) {
+      const source = await readFile(new URL(filename, migrationsUrl), "utf8");
+      for (const statement of source
+        .replaceAll('"public".', `"${testSchema}".`)
+        .split("--> statement-breakpoint")) {
+        if (statement.trim()) await client.unsafe(statement);
+      }
+    }
+    try {
+      await client.unsafe(`CREATE SCHEMA "${testSchema}"`);
+      await client.unsafe(
+        "CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public",
+      );
+      await client.unsafe(`SET search_path TO "${testSchema}", public`);
+      const migrations = (await readdir(migrationsUrl))
+        .filter((name) => /^\d{4}_.+\.sql$/.test(name))
+        .sort();
+      for (const migration of migrations.filter((name) => name < "0038_"))
+        await apply(migration);
+      await client`INSERT INTO profiles (id, email, display_name) VALUES (${userA}, ${`${userA}@example.test`}, 'A'), (${userB}, ${`${userB}@example.test`}, 'B')`;
+      await client`INSERT INTO connected_accounts (id, user_id, provider_account_id, email, memory_acknowledged_at) VALUES (${accountId}, ${userA}, ${providerAccountId}, 'shared@example.test', now())`;
+      await client`INSERT INTO account_secrets (account_id, token_ciphertext, key_version) VALUES (${accountId}, 'test-encrypted-grant', 1)`;
+      await client`INSERT INTO gmail_replica_states (account_id, initial_history_id, history_cursor, pending_history_cursor, state) VALUES (${accountId}, '100', '200', '300', 'ready')`;
+      await client`INSERT INTO labels (id, user_id, account_id, kind, name, normalized_name, description) VALUES (${labelId}, ${userA}, ${accountId}, 'invook', 'Private', 'private', 'Preserved definition')`;
+      const before =
+        await client`SELECT a.*, s.token_ciphertext, r.history_cursor, r.pending_history_cursor FROM connected_accounts a JOIN account_secrets s ON s.account_id=a.id JOIN gmail_replica_states r ON r.account_id=a.id`;
+      await apply("0038_shared_gmail_connections.sql");
+      assert.deepEqual(
+        await client`SELECT a.*, s.token_ciphertext, r.history_cursor, r.pending_history_cursor FROM connected_accounts a JOIN account_secrets s ON s.account_id=a.id JOIN gmail_replica_states r ON r.account_id=a.id`,
+        before,
+      );
+      assert.equal(
+        (await client`SELECT description FROM labels WHERE id=${labelId}`)[0]
+          ?.description,
+        "Preserved definition",
+      );
+      await client`INSERT INTO connected_accounts (user_id, provider_account_id, email, memory_acknowledged_at) VALUES (${userB}, ${providerAccountId}, 'shared@example.test', now())`;
+      await assert.rejects(
+        client`INSERT INTO connected_accounts (user_id, provider_account_id, email, memory_acknowledged_at) VALUES (${userA}, ${providerAccountId}, 'shared@example.test', now())`,
+        (error: unknown) =>
+          error instanceof postgres.PostgresError && error.code === "23505",
+      );
+      assert.equal(
+        (await client`SELECT count(*)::int AS count FROM connected_accounts`)[0]
+          ?.count,
+        2,
+      );
+      assert.ok(
+        (
+          await client`SELECT to_regclass('historical_thread_label_scans') AS name`
+        )[0]?.name,
+      );
+    } finally {
+      await client.unsafe("SET search_path TO public");
+      await client.unsafe(`DROP SCHEMA IF EXISTS "${testSchema}" CASCADE`);
+      await client.end();
+    }
+  },
+);

--- a/packages/database/src/workflows.ts
+++ b/packages/database/src/workflows.ts
@@ -1033,7 +1033,7 @@ export async function markWorkflowStepRunning(
 export async function completeWorkflowStep(
   stepId: string,
   result: Record<string, unknown> = {},
-  database: Database = getDatabase(),
+  database: DatabaseExecutor = getDatabase(),
 ) {
   return database.transaction(async (transaction) => {
     const [step] = await transaction
@@ -1075,7 +1075,7 @@ export async function completeWorkflowStep(
       })
       .where(eq(workflowSteps.id, stepId));
 
-    if (step.stepType !== "gmail.account.cleanup" || !step.accountId) return true;
+    if (step.stepType !== "gmail.account.cleanup" || !step.accountId || result.status === "inactive") return true;
     const cleanupId =
       typeof step.input.cleanupId === "string" ? step.input.cleanupId : null;
     if (!cleanupId) {
@@ -1091,10 +1091,16 @@ export async function completeWorkflowStep(
         completedAt: new Date(),
         updatedAt: new Date(),
       })
-      .where(eq(gmailAccountCleanups.id, cleanupId));
+      .where(and(
+        eq(gmailAccountCleanups.id, cleanupId),
+        eq(gmailAccountCleanups.accountId, step.accountId),
+      ));
     await transaction
       .delete(connectedAccounts)
-      .where(eq(connectedAccounts.id, step.accountId));
+      .where(and(
+        eq(connectedAccounts.id, step.accountId),
+        eq(connectedAccounts.status, "disconnected"),
+      ));
     return true;
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,12 @@ importers:
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(postgres@3.4.9)
+      postgres:
+        specifier: ^3.4.7
+        version: 3.4.9
       tsx:
         specifier: ^4.20.0
         version: 4.23.11

--- a/scripts/run-database-tests.mjs
+++ b/scripts/run-database-tests.mjs
@@ -30,7 +30,15 @@ if (testFiles.length === 0) {
 
 const child = spawn(
   process.execPath,
-  ["--import", "tsx", "--test", ...testFiles],
+  [
+    "--import", "tsx", "--test",
+    // Integration files share one disposable database. Historical migrations
+    // create/drop database-wide extensions; global reconciliation scans also
+    // inspect other fixtures. Keep files serial while tests exercise explicit
+    // concurrency through independent transactions and connections.
+    ...(mode === "integration" ? ["--test-concurrency=1"] : []),
+    ...testFiles,
+  ],
   { env: process.env, stdio: "inherit" },
 );
 child.once("error", (error) => {


### PR DESCRIPTION
## Summary

- scope Gmail OAuth lookup, credential fallback, reconnect, and uniqueness by Invook user plus provider identity
- fan verified Pub/Sub notifications out to every active internal connection with independent non-waiting durable admission and account-specific Temporal idempotency
- serialize watch start, renewal, disconnect, stop, and final cleanup by Gmail identity while keeping each replica connection-scoped
- add migration 0038 after PR #45 migrations 0036/0037, preserving existing IDs and stored data
- add four-connection, ownership, credential, fan-out, retry, watch, disconnect, reconnect, cleanup, and migration coverage

## Verification

- `make verify`
- clean migration apply through 0038 against a disposable PostgreSQL 17 database
- `TEST_DATABASE_URL=<disposable> make verify-database` (39 passed)
- focused Gmail watch lifecycle database tests (5 passed)
- `docker compose -f docker/compose.yml config --quiet`

## Dependency and external verification

This PR is intentionally stacked on #45 and should land after it. Live Google OAuth with two real Invook users, live Gmail watch replacement/stop, Pub/Sub redelivery, Temporal Cloud execution, and real mailbox convergence were not exercised in this isolated worktree.