### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,19 @@
+{
+  "name": "Invook",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh",
+  "terminals": [
+    {
+      "name": "api",
+      "command": "pnpm dev:api"
+    },
+    {
+      "name": "web",
+      "command": "pnpm dev:web"
+    }
+  ],
+  "ports": [
+    { "name": "web", "port": 3000 },
+    { "name": "api", "port": 4000 }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for Invook.
+#
+# Installs the local infrastructure that `make dev` normally provides through
+# Docker (PostgreSQL with pgvector and a MinIO S3-compatible store), installs
+# workspace dependencies, initializes a user-owned PostgreSQL cluster, and
+# scaffolds a local .env.local. Runtime services are launched by start.sh.
+set -euo pipefail
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$repo_root"
+
+state_dir="${INVOOK_STATE_DIR:-$HOME/.invook}"
+pgdata="$state_dir/pgdata"
+minio_data="$state_dir/minio"
+mkdir -p "$state_dir/logs" "$minio_data"
+
+pg_bindir="/usr/lib/postgresql/16/bin"
+
+echo "==> Installing system packages (PostgreSQL 16, pgvector, tooling)"
+sudo apt-get update -qq
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+  postgresql-16 postgresql-16-pgvector postgresql-client-16 ca-certificates curl
+
+echo "==> Installing MinIO server and client"
+if ! command -v minio >/dev/null 2>&1; then
+  sudo curl -fsSL https://dl.min.io/server/minio/release/linux-amd64/minio -o /usr/local/bin/minio
+  sudo chmod +x /usr/local/bin/minio
+fi
+if ! command -v mc >/dev/null 2>&1; then
+  sudo curl -fsSL https://dl.min.io/client/mc/release/linux-amd64/mc -o /usr/local/bin/mc
+  sudo chmod +x /usr/local/bin/mc
+fi
+
+echo "==> Installing workspace dependencies"
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+corepack enable
+pnpm install --frozen-lockfile
+
+echo "==> Initializing PostgreSQL cluster"
+if [ ! -s "$pgdata/PG_VERSION" ]; then
+  "$pg_bindir/initdb" \
+    --username=invook \
+    --auth-local=trust \
+    --auth-host=trust \
+    --encoding=UTF8 \
+    --pgdata="$pgdata" >/dev/null
+  {
+    echo "port = 54322"
+    echo "listen_addresses = '127.0.0.1'"
+    echo "unix_socket_directories = '/tmp'"
+  } >>"$pgdata/postgresql.conf"
+fi
+
+echo "==> Scaffolding .env.local"
+if [ ! -f .env.local ]; then
+  cp .env.example .env.local
+  better_auth_secret=$(openssl rand -base64 32)
+  token_encryption_key=$(openssl rand -base64 32)
+  # Populate local-only secrets so the stack boots. Provider credentials
+  # (Google OAuth, Temporal Cloud, AI) are injected from Cursor Secrets at
+  # runtime and intentionally left blank here.
+  sed -i "s|^BETTER_AUTH_SECRET=.*|BETTER_AUTH_SECRET=${better_auth_secret}|" .env.local
+  sed -i "s|^TOKEN_ENCRYPTION_KEY=.*|TOKEN_ENCRYPTION_KEY=${token_encryption_key}|" .env.local
+fi
+
+echo "==> Install complete"

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Idempotent per-boot startup for Invook local infrastructure.
+#
+# Starts the user-owned PostgreSQL cluster and MinIO store, ensures the
+# application database and object-storage bucket exist, and applies database
+# migrations. Application dev servers (API and web) run as tmux terminals.
+set -euo pipefail
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$repo_root"
+
+state_dir="${INVOOK_STATE_DIR:-$HOME/.invook}"
+pgdata="$state_dir/pgdata"
+minio_data="$state_dir/minio"
+log_dir="$state_dir/logs"
+mkdir -p "$log_dir"
+
+pg_bindir="/usr/lib/postgresql/16/bin"
+
+# Load local environment (S3 credentials, database URL) if present.
+if [ -f .env.local ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env.local
+  set +a
+fi
+
+s3_access_key="${S3_ACCESS_KEY_ID:-invook}"
+s3_secret_key="${S3_SECRET_ACCESS_KEY:-invook-local-secret}"
+s3_bucket="${S3_BUCKET:-invook-mail}"
+
+echo "==> Starting PostgreSQL"
+if ! "$pg_bindir/pg_ctl" -D "$pgdata" status >/dev/null 2>&1; then
+  "$pg_bindir/pg_ctl" -D "$pgdata" -l "$log_dir/postgres.log" -w start
+fi
+
+# Wait for readiness, then ensure the application database exists.
+"$pg_bindir/pg_isready" -h 127.0.0.1 -p 54322 -t 30 >/dev/null
+if ! psql -h 127.0.0.1 -p 54322 -U invook -tAc \
+  "SELECT 1 FROM pg_database WHERE datname='invook'" | grep -q 1; then
+  createdb -h 127.0.0.1 -p 54322 -U invook invook
+fi
+
+echo "==> Starting MinIO"
+if ! curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null 2>&1; then
+  MINIO_ROOT_USER="$s3_access_key" \
+  MINIO_ROOT_PASSWORD="$s3_secret_key" \
+    nohup minio server "$minio_data" --address ":9000" --console-address ":9001" \
+    >"$log_dir/minio.log" 2>&1 &
+fi
+
+# Wait for MinIO to become live, then ensure the bucket exists.
+for _ in $(seq 1 30); do
+  if curl -fsS http://127.0.0.1:9000/minio/health/live >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+mc alias set invook-local http://127.0.0.1:9000 "$s3_access_key" "$s3_secret_key" >/dev/null
+mc mb --ignore-existing "invook-local/$s3_bucket" >/dev/null
+
+echo "==> Applying database migrations"
+pnpm db:migrate
+
+echo "==> Startup complete"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up a Cloud Agent development environment for Invook so future agents boot into a working stack. Since Docker-in-VM is fragile in Cloud Agent VMs, this provisions the same local infrastructure `make dev` provides via Docker Compose — PostgreSQL 16 with pgvector and a MinIO S3-compatible store — as lightweight user-owned native services.

## What's included

- `.cursor/install.sh` — idempotent bootstrap: installs PostgreSQL 16 + pgvector + MinIO, runs `pnpm install --frozen-lockfile`, initializes a user-owned Postgres cluster on port `54322`, and scaffolds `.env.local` (local infra defaults + generated `BETTER_AUTH_SECRET`/`TOKEN_ENCRYPTION_KEY`).
- `.cursor/start.sh` — idempotent per-boot startup: starts Postgres and MinIO, ensures the `invook` database and `invook-mail` bucket exist, and applies Drizzle migrations.
- `.cursor/environment.json` — wires `install`, `start`, and the `api`/`web` dev-server terminals, and exposes ports 3000/4000.

Provider credentials (Google OAuth, Temporal Cloud, AI) are read from Cursor Secrets at runtime (Node's env-file loader does not override already-set process env), so they are intentionally left blank in the scaffolded `.env.local`.

## Validation

- `make verify` (typecheck, lint, test, build) passes — API 79, web 76, worker 33, auth 2 tests green; web build compiled successfully.
- Postgres cluster boots; 39 Drizzle migrations apply cleanly (30 tables), including the historical pgvector-dependent migrations.
- MinIO healthy with the `invook-mail` bucket created.
- API boots on `:4000` (`/health/live` → ok, `/v1/session` → real unauthenticated response); web boots on `:3000` and renders the Invook sign-in UI, proxying `/v1/*` to the API.

## Out of scope / requires secrets

Google sign-in, Gmail sync, Temporal-backed durable work, and AI features require external credentials and remain unverified until those secrets are provided.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d3c9087-7712-4685-bd87-15d28f6fd85b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d3c9087-7712-4685-bd87-15d28f6fd85b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

